### PR TITLE
Added support for sorting results by total, self, wait and child times.

### DIFF
--- a/bin/ruby-prof
+++ b/bin/ruby-prof
@@ -107,7 +107,7 @@ opts = OptionParser.new do |opts|
 
   opts.on('-s sort_mode', '--sort=sort_mode', [:total, :self, :wait, :child],
       'Select how ruby-prof results should be sorted:',
-      '  total - Total time (default)',
+      '  total - Total time',
       '  self - Self time',
       '  wait - Wait time',
       '  child - Child time') do |sort_mode|
@@ -202,8 +202,8 @@ at_exit {
   result = RubyProf.stop
 
   # Create a printer
+  printer = options.printer.new(result)
   printer_options = {:min_percent => options.min_percent, :sort_method => options.sort_method}
-  printer = options.printer.new(result, printer_options)
 
   # Get output
   if options.file

--- a/lib/ruby-prof/abstract_printer.rb
+++ b/lib/ruby-prof/abstract_printer.rb
@@ -2,10 +2,10 @@
 
 module RubyProf
   class AbstractPrinter
-    def initialize(result, options = {})
+    def initialize(result)
       @result = result
       @output = nil
-      @options = options
+      @options = {}
     end
 
     # Specify print options.

--- a/lib/ruby-prof/dot_printer.rb
+++ b/lib/ruby-prof/dot_printer.rb
@@ -23,8 +23,8 @@ module RubyProf
     EDGE_COLOR  = '"#666666"'
     
     # Creates the DotPrinter using a RubyProf::Result.
-    def initialize(result, options = {})
-      super(result, options)
+    def initialize(result)
+      super(result)
       @seen_methods = Set.new
     end
         

--- a/lib/ruby-prof/flat_printer.rb
+++ b/lib/ruby-prof/flat_printer.rb
@@ -12,17 +12,9 @@ module RubyProf
   #   printer.print(STDOUT, {})
   #
   class FlatPrinter < AbstractPrinter
-
-    def initialize(results, options = {})
-      # Now sort methods by largest self time by default,
-      # not total time like in other printouts
-      options[:sort_method] ||= :self_time
-      super(results, options)
-    end
-
     # Print a flat profile report to the provided output.
     #
-    # output - Any IO oject, including STDOUT or a file.
+    # output - Any IO object, including STDOUT or a file.
     # The default value is STDOUT.
     #
     # options - Hash of print options.  See #setup_options
@@ -30,6 +22,9 @@ module RubyProf
     #
     def print(output = STDOUT, options = {})
       @output = output
+      # Now sort methods by largest self time by default,
+      # not total time like in other printouts
+      options[:sort_method] ||= :self_time
       setup_options(options)
       print_threads
     end

--- a/lib/ruby-prof/flat_printer_with_line_numbers.rb
+++ b/lib/ruby-prof/flat_printer_with_line_numbers.rb
@@ -13,13 +13,6 @@ module RubyProf
   #
   class FlatPrinterWithLineNumbers < FlatPrinter
 
-    def initialize(results, options = {})
-      # Now sort methods by largest self time by default,
-      # not total time like in other printouts
-      options[:sort_method] ||= :self_time
-      super(results, options)
-    end
-
     def print_methods(thread_id, methods)
       # Get total time
       toplevel = methods.max

--- a/lib/ruby-prof/graph_html_printer.rb
+++ b/lib/ruby-prof/graph_html_printer.rb
@@ -30,8 +30,8 @@ module RubyProf
 
     # Create a GraphPrinter.  Result is a RubyProf::Result
     # object generated from a profiling run.
-    def initialize(result, options = {})
-      super(result, options)
+    def initialize(result)
+      super(result)
       @thread_times = Hash.new
       calculate_thread_times
     end

--- a/lib/ruby-prof/graph_printer.rb
+++ b/lib/ruby-prof/graph_printer.rb
@@ -20,8 +20,8 @@ module RubyProf
 
     # Create a GraphPrinter.  Result is a RubyProf::Result
     # object generated from a profiling run.
-    def initialize(result, options = {})
-      super(result, options)
+    def initialize(result)
+      super(result)
       @thread_times = Hash.new
       calculate_thread_times
     end

--- a/lib/ruby-prof/multi_printer.rb
+++ b/lib/ruby-prof/multi_printer.rb
@@ -5,11 +5,11 @@ module RubyProf
   # one profiling run. Currently prints a flat profile, a callgrind
   # profile, a call stack profile and a graph profile.
   class MultiPrinter
-    def initialize(result, options = {})
-      @stack_printer = CallStackPrinter.new(result, options)
-      @graph_printer = GraphHtmlPrinter.new(result, options)
-      @tree_printer = CallTreePrinter.new(result, options)
-      @flat_printer = FlatPrinter.new(result, options)
+    def initialize(result)
+      @stack_printer = CallStackPrinter.new(result)
+      @graph_printer = GraphHtmlPrinter.new(result)
+      @tree_printer = CallTreePrinter.new(result)
+      @flat_printer = FlatPrinter.new(result)
     end
 
     # create profile files under options[:path] or the current


### PR DESCRIPTION
I've added support for sorting profiling results from command line or directly. The main reason for this is I almost never found the graph_html usable when sorted by total time. Every time I used it, I needed some different sorting.

What do you think?
