### PR TITLE
cast time.tv_sec to prof_measure_t before multiplying, in measure_process

### DIFF
--- a/ext/ruby_prof/measure_process_time.h
+++ b/ext/ruby_prof/measure_process_time.h
@@ -34,7 +34,8 @@ measure_process_time()
 #if defined(__linux__)
     struct timespec time;
     clock_gettime(CLOCK_PROCESS_CPUTIME_ID , &time);
-    return time.tv_sec * 1000000000 + time.tv_nsec ;
+    //cast time.tv_sec to our return type, so it's properly sized, then multiply it out to nanoseconds and add time.tv_nsec
+    return ((prof_measure_t) time.tv_sec) * 1000000000 + time.tv_nsec ;
 #else
     return clock();
 #endif


### PR DESCRIPTION
fix for https://github.com/rdp/ruby-prof/issues/61

I don't know a good way to write a test for this, unfortunately.

explanation of fix in commit message. I hope it makes sense.
