### PR TITLE
Silence warnings for assigned but unused variables.

### DIFF
--- a/lib/ruby-prof/printers/dot_printer.rb
+++ b/lib/ruby-prof/printers/dot_printer.rb
@@ -96,7 +96,7 @@ module RubyProf
       thread.methods.each{|m| grouped[m.klass_name] ||= []; grouped[m.klass_name] << m}
       grouped.each do |cls, methods2|
         # Filter down to just seen methods
-        big_methods, small_methods  = methods2.partition{|m| @seen_methods.include? m}
+        big_methods = methods2.select{|m| @seen_methods.include? m}
         
         if !big_methods.empty?
           puts "subgraph cluster_#{cls.object_id} {"

--- a/lib/ruby-prof/printers/graph_html_printer.rb
+++ b/lib/ruby-prof/printers/graph_html_printer.rb
@@ -40,7 +40,6 @@ module RubyProf
     def print(output = STDOUT, options = {})
       @output = output
       setup_options(options)
-      _erbout = @output
       @output << @erb.result(binding)
     end
 

--- a/test/prime.rb
+++ b/test/prime.rb
@@ -51,5 +51,5 @@ def run_primes(length=10, maxnum=1000)
   primes = find_primes(random_array)
 
   # Find the largest primes
-  largest = find_largest(primes)
+  find_largest(primes)
 end


### PR DESCRIPTION
Get rid of the three warnings for assigned but unused variables.
