### PR TITLE
Add prof_ prefix for names of functions for prof_frame_t and prof_stack_t

### DIFF
--- a/ext/ruby_prof/rp_stack.c
+++ b/ext/ruby_prof/rp_stack.c
@@ -6,16 +6,16 @@
 #define INITIAL_STACK_SIZE 8
 
 void
-frame_pause(prof_frame_t *frame, double current_measurement)
+prof_frame_pause(prof_frame_t *frame, double current_measurement)
 {
-    if (frame && frame_is_unpaused(frame))
+    if (frame && prof_frame_is_unpaused(frame))
         frame->pause_time = current_measurement;
 }
 
 void
-frame_unpause(prof_frame_t *frame, double current_measurement)
+prof_frame_unpause(prof_frame_t *frame, double current_measurement)
 {
-    if (frame && frame_is_paused(frame)) {
+    if (frame && prof_frame_is_paused(frame)) {
         frame->dead_time += (current_measurement - frame->pause_time);
         frame->pause_time = -1;
     }
@@ -25,7 +25,7 @@ frame_unpause(prof_frame_t *frame, double current_measurement)
 /* Creates a stack of prof_frame_t to keep track
    of timings for active methods. */
 prof_stack_t *
-stack_create()
+prof_stack_create()
 {
     prof_stack_t *stack = ALLOC(prof_stack_t);
     stack->start = ALLOC_N(prof_frame_t, INITIAL_STACK_SIZE);
@@ -36,14 +36,14 @@ stack_create()
 }
 
 void
-stack_free(prof_stack_t *stack)
+prof_stack_free(prof_stack_t *stack)
 {
     xfree(stack->start);
     xfree(stack);
 }
 
 prof_frame_t *
-stack_push(prof_stack_t *stack)
+prof_stack_push(prof_stack_t *stack)
 {
   prof_frame_t* result = NULL;
 
@@ -74,7 +74,7 @@ stack_push(prof_stack_t *stack)
 }
 
 prof_frame_t *
-stack_pop(prof_stack_t *stack)
+prof_stack_pop(prof_stack_t *stack)
 {
     if (stack->ptr == stack->start)
       return NULL;
@@ -83,7 +83,7 @@ stack_pop(prof_stack_t *stack)
 }
 
 prof_frame_t *
-stack_peek(prof_stack_t *stack)
+prof_stack_peek(prof_stack_t *stack)
 {
     if (stack->ptr == stack->start)
       return NULL;

--- a/ext/ruby_prof/rp_stack.h
+++ b/ext/ruby_prof/rp_stack.h
@@ -28,10 +28,10 @@ typedef struct
     unsigned int line;
 } prof_frame_t;
 
-#define frame_is_paused(f) (f->pause_time >= 0)
-#define frame_is_unpaused(f) (f->pause_time < 0)
-void frame_pause(prof_frame_t*, double current_measurement);
-void frame_unpause(prof_frame_t*, double current_measurement);
+#define prof_frame_is_paused(f) (f->pause_time >= 0)
+#define prof_frame_is_unpaused(f) (f->pause_time < 0)
+void prof_frame_pause(prof_frame_t*, double current_measurement);
+void prof_frame_unpause(prof_frame_t*, double current_measurement);
 
 
 /* Current stack of active methods.*/
@@ -42,10 +42,10 @@ typedef struct
     prof_frame_t *ptr;
 } prof_stack_t;
 
-prof_stack_t * stack_create();
-void stack_free(prof_stack_t *stack);
-prof_frame_t * stack_push(prof_stack_t *stack);
-prof_frame_t * stack_pop(prof_stack_t *stack);
-prof_frame_t * stack_peek(prof_stack_t *stack);
+prof_stack_t * prof_stack_create();
+void prof_stack_free(prof_stack_t *stack);
+prof_frame_t * prof_stack_push(prof_stack_t *stack);
+prof_frame_t * prof_stack_pop(prof_stack_t *stack);
+prof_frame_t * prof_stack_peek(prof_stack_t *stack);
 
 #endif //__RP_STACK__

--- a/ext/ruby_prof/rp_thread.c
+++ b/ext/ruby_prof/rp_thread.c
@@ -10,7 +10,7 @@ thread_data_t*
 thread_data_create()
 {
     thread_data_t* result = ALLOC(thread_data_t);
-    result->stack = stack_create();
+    result->stack = prof_stack_create();
     result->method_table = method_table_create();
 	result->top = NULL;
 	result->object = Qnil;
@@ -44,7 +44,7 @@ thread_data_free(thread_data_t* thread_data)
 	thread_data_ruby_gc_free(thread_data);
     thread_data->top = NULL;
     method_table_free(thread_data->method_table);
-    stack_free(thread_data->stack);
+    prof_stack_free(thread_data->stack);
 
     thread_data->thread_id = Qnil;
 
@@ -157,7 +157,7 @@ switch_thread(void* prof, VALUE thread_id)
     thread_data_t *thread_data = threads_table_lookup(profile, thread_id);
 
     /* Get current frame for this thread */
-    prof_frame_t *frame = stack_peek(thread_data->stack);
+    prof_frame_t *frame = prof_stack_peek(thread_data->stack);
 
     /* Update the time this thread waited for another thread */
     if (frame)
@@ -170,7 +170,7 @@ switch_thread(void* prof, VALUE thread_id)
        and reset this thread's last context switch to 0.*/
     if (profile->last_thread_data)
     {
-       prof_frame_t *last_frame = stack_peek(profile->last_thread_data->stack);
+       prof_frame_t *last_frame = prof_stack_peek(profile->last_thread_data->stack);
        if (last_frame)
          last_frame->switch_time = measurement;
     }


### PR DESCRIPTION
The current ruby-prof cannot be used together with redcarpet because of occurring segmentation fault.  The reason why the segv is occurred is that ruby-prof and redcarpet have functions with the same names, such as `stack_push`.  When you load ruby-prof before loading redcarpet, redcarpet internally uses ruby-prof's stack functions.

I think both libraries should change these generic names to library-specific names.
