### PR TITLE
fix for seg fault when accessing rubyprof_options and undefined method 'eliminate_methods' when accessing rubyprof_options

### DIFF
--- a/bin/ruby-prof
+++ b/bin/ruby-prof
@@ -17,13 +17,13 @@ require 'ostruct'
 require 'optparse'
 require File.expand_path('../../lib/ruby-prof', __FILE__)
 
-rubyprof_options = OpenStruct.new
-rubyprof_options.measure_mode = RubyProf::PROCESS_TIME
-rubyprof_options.printer = RubyProf::FlatPrinter
-rubyprof_options.min_percent = 0
-rubyprof_options.file = nil
-rubyprof_options.replace_prog_name = false
-rubyprof_options.specialized_instruction = false
+@rubyprof_options = OpenStruct.new
+@rubyprof_options.measure_mode = RubyProf::PROCESS_TIME
+@rubyprof_options.printer = RubyProf::FlatPrinter
+@rubyprof_options.min_percent = 0
+@rubyprof_options.file = nil
+@rubyprof_options.replace_prog_name = false
+@rubyprof_options.specialized_instruction = false
 
 opts = OptionParser.new do |opts|
   opts.banner = "ruby_prof #{RubyProf::VERSION}\n" +
@@ -47,19 +47,19 @@ opts = OptionParser.new do |opts|
           
     case printer
       when :flat
-        rubyprof_options.printer = RubyProf::FlatPrinter
+        @rubyprof_options.printer = RubyProf::FlatPrinter
       when :flat_with_line_numbers
-        rubyprof_options.printer = RubyProf::FlatPrinterWithLineNumbers
+        @rubyprof_options.printer = RubyProf::FlatPrinterWithLineNumbers
       when :graph
-        rubyprof_options.printer = RubyProf::GraphPrinter
+        @rubyprof_options.printer = RubyProf::GraphPrinter
       when :graph_html
-        rubyprof_options.printer = RubyProf::GraphHtmlPrinter
+        @rubyprof_options.printer = RubyProf::GraphHtmlPrinter
       when :call_tree
-        rubyprof_options.printer = RubyProf::CallTreePrinter
+        @rubyprof_options.printer = RubyProf::CallTreePrinter
       when :call_stack
-        rubyprof_options.printer = RubyProf::CallStackPrinter
+        @rubyprof_options.printer = RubyProf::CallStackPrinter
       when :dot
-        rubyprof_options.printer = RubyProf::DotPrinter
+        @rubyprof_options.printer = RubyProf::DotPrinter
     end
   end
     
@@ -67,13 +67,13 @@ opts = OptionParser.new do |opts|
           'The minimum percent a method must take before ',
           '  being included in output reports.',
                                         '  this option is not supported for call tree.') do |min_percent|
-    rubyprof_options.min_percent = min_percent
+    @rubyprof_options.min_percent = min_percent
   end
 
   opts.on('-f path', '--file=path',
         'Output results to a file instead of standard out.') do |file|
-    rubyprof_options.file = file
-    rubyprof_options.old_wd = Dir.pwd
+    @rubyprof_options.file = file
+    @rubyprof_options.old_wd = Dir.pwd
   end
     
   opts.on('--mode=measure_mode',
@@ -89,19 +89,19 @@ opts = OptionParser.new do |opts|
       
       case measure_mode
       when :process
-        rubyprof_options.measure_mode = RubyProf::PROCESS_TIME     
+        @rubyprof_options.measure_mode = RubyProf::PROCESS_TIME     
       when :wall
-        rubyprof_options.measure_mode = RubyProf::WALL_TIME      
+        @rubyprof_options.measure_mode = RubyProf::WALL_TIME      
       when :cpu
-        rubyprof_options.measure_mode = RubyProf::CPU_TIME
+        @rubyprof_options.measure_mode = RubyProf::CPU_TIME
       when :allocations
-        rubyprof_options.measure_mode = RubyProf::ALLOCATIONS
+        @rubyprof_options.measure_mode = RubyProf::ALLOCATIONS
       when :memory
-        rubyprof_options.measure_mode = RubyProf::MEMORY
+        @rubyprof_options.measure_mode = RubyProf::MEMORY
       when :gc_runs
-        rubyprof_options.measure_mode = RubyProf::GC_RUNS
+        @rubyprof_options.measure_mode = RubyProf::GC_RUNS
       when :gc_time
-        rubyprof_options.measure_mode = RubyProf::GC_TIME
+        @rubyprof_options.measure_mode = RubyProf::GC_TIME
       end
   end
 
@@ -112,7 +112,7 @@ opts = OptionParser.new do |opts|
       '  wait - Wait time',
       '  child - Child time') do |sort_mode|
 
-      rubyprof_options.sort_method = case sort_mode
+      @rubyprof_options.sort_method = case sort_mode
         when :total
           :total_time
         when :self
@@ -125,12 +125,12 @@ opts = OptionParser.new do |opts|
   end
 
   opts.on("--replace-progname", "Replace $0 when loading the .rb files.") do
-          rubyprof_options.replace_prog_name = true
+          @rubyprof_options.replace_prog_name = true
   end
 
   if defined?(VM)
     opts.on("--specialized-instruction", "Turn on specified instruction.") do
-            rubyprof_options.specialized_instruction = true
+            @rubyprof_options.specialized_instruction = true
     end
   end
     
@@ -154,38 +154,38 @@ opts = OptionParser.new do |opts|
   end
 
   opts.on('-R lib', '--require-noprof lib', 'require a specific library (not profiled)') do |lib|
-      rubyprof_options.pre_libs ||= []
-      rubyprof_options.pre_libs << lib
+      @rubyprof_options.pre_libs ||= []
+      @rubyprof_options.pre_libs << lib
   end
 
   opts.on('-E code', '--eval-noprof code', 'execute the ruby statements (not profiled)') do |code|
-      rubyprof_options.pre_exec ||= []
-      rubyprof_options.pre_exec << code
+      @rubyprof_options.pre_exec ||= []
+      @rubyprof_options.pre_exec << code
   end
 
   opts.on('-r lib', '--require lib', 'require a specific library') do |lib|
-      rubyprof_options.libs ||= []
-      rubyprof_options.libs << lib
+      @rubyprof_options.libs ||= []
+      @rubyprof_options.libs << lib
   end
 
   opts.on('-e code', '--eval', 'execute the ruby statements') do |code|
-      rubyprof_options.exec ||= []
-      rubyprof_options.exec << code
+      @rubyprof_options.exec ||= []
+      @rubyprof_options.exec << code
   end
 
   opts.on('-x regexp', '--exclude regexp', 'exclude methods by regexp (see method elimination)') do|meth|
-    rubyprof_options.eliminate_methods ||= []
-    rubyprof_options.eliminate_methods << Regexp.new(meth)
+    @rubyprof_options.eliminate_methods ||= []
+    @rubyprof_options.eliminate_methods << Regexp.new(meth)
   end
 
   opts.on('-X file', '--exclude-file file', 'exclude methods by regexp listed in file (see method elimination)') do|file|
-    rubyprof_options.eliminate_methods_files ||= []
-    rubyprof_options.eliminate_methods_files << file
+    @rubyprof_options.eliminate_methods_files ||= []
+    @rubyprof_options.eliminate_methods_files << file
   end
 
   opts.on('--exclude-common-cycles', 'make common iterators like Integer#times appear inlined') do|meth|
-    rubyprof_options.eliminate_methods ||= []
-    rubyprof_options.eliminate_methods += %w{
+    @rubyprof_options.eliminate_methods ||= []
+    @rubyprof_options.eliminate_methods += %w{
       Integer#times
       Integer#upto
       Integer#downto
@@ -218,8 +218,8 @@ opts = OptionParser.new do |opts|
   end
 
   opts.on('--exclude-common-callbacks', 'make common callbacks invocations like Integer#times appear inlined so you can see call origins in graph') do|meth|
-    rubyprof_options.eliminate_methods ||= []
-    rubyprof_options.eliminate_methods += %w{
+    @rubyprof_options.eliminate_methods ||= []
+    @rubyprof_options.eliminate_methods += %w{
       Method#call
       Proc#call
       ActiveSupport::Callbacks::ClassMethods#__run_callback
@@ -238,7 +238,7 @@ rescue OptionParser::InvalidOption, OptionParser::InvalidArgument,
 end
 
 # Make sure the user specified at least one file
-if ARGV.length < 1 and not rubyprof_options.exec
+if ARGV.length < 1 and not @rubyprof_options.exec
   puts opts
   puts ""
   puts "Must specify a script to run"
@@ -255,18 +255,18 @@ at_exit {
   result = RubyProf.stop
 
   # Eliminate unwanted methods from call graph
-  result.eliminate_methods! rubyprof_options.eliminate_methods if rubyprof_options.eliminate_methods
-  rubyprof_options.eliminate_methods_files.each{|f| result.eliminate_methods!(f)} if rubyprof_options.eliminate_methods_files
+  result.eliminate_methods! @rubyprof_options.eliminate_methods if @rubyprof_options.eliminate_methods
+  @rubyprof_options.eliminate_methods_files.each{|f| result.eliminate_methods!(f)} if @rubyprof_options.eliminate_methods_files
 
   # Create a printer
-  printer = rubyprof_options.printer.new(result)
-  printer_options = {:min_percent => rubyprof_options.min_percent, :sort_method => rubyprof_options.sort_method}
+  printer = @rubyprof_options.printer.new(result)
+  printer_options = {:min_percent => @rubyprof_options.min_percent, :sort_method => @rubyprof_options.sort_method}
 
   # Get output
-  if rubyprof_options.file
+  if @rubyprof_options.file
     # write it relative to the dir they *started* in, as it's a bit surprising to write it in the dir they end up in.
-    Dir.chdir(rubyprof_options.old_wd) do
-      File.open(rubyprof_options.file, 'w') do |file|
+    Dir.chdir(@rubyprof_options.old_wd) do
+      File.open(@rubyprof_options.file, 'w') do |file|
         printer.print(file, printer_options)
       end
     end
@@ -277,33 +277,33 @@ at_exit {
 }
 
 # Now set measure mode
-RubyProf.measure_mode = rubyprof_options.measure_mode
+RubyProf.measure_mode = @rubyprof_options.measure_mode
 
 # Set VM compile option
 if defined?(VM)
   VM::InstructionSequence.compile_option = {
     :trace_instruction => true,
-    :specialized_instruction => rubyprof_options.specialized_instruction
+    :specialized_instruction => @rubyprof_options.specialized_instruction
   }
 end
 
 # Get the script we will execute
 script = ARGV.shift
-if rubyprof_options.replace_prog_name
+if @rubyprof_options.replace_prog_name
   $0 = File.expand_path(script)
 end
 
-if rubyprof_options.pre_libs
-  rubyprof_options.pre_libs.each { |l| require l }
+if @rubyprof_options.pre_libs
+  @rubyprof_options.pre_libs.each { |l| require l }
 end
 
-if rubyprof_options.pre_exec
-  rubyprof_options.pre_exec.each { |c| eval c }
+if @rubyprof_options.pre_exec
+  @rubyprof_options.pre_exec.each { |c| eval c }
 end
 
 # do not pollute profiling report with OpenStruct#libs
-ol = rubyprof_options.libs
-oe = rubyprof_options.exec
+ol = @rubyprof_options.libs
+oe = @rubyprof_options.exec
 
 # Start profiling
 RubyProf.start 


### PR DESCRIPTION
rubyprof_options needs to be an instance variable @rubyprof_options instead of a local variable rubyprof_options to overcome problems when referring to it within the block passed to at_exit. 

https://github.com/rdp/ruby-prof/issues/83
https://github.com/rdp/ruby-prof/issues/95
