### PR TITLE
Stretch background color on very wide call stacks

### DIFF
--- a/lib/ruby-prof/printers/call_stack_printer.rb
+++ b/lib/ruby-prof/printers/call_stack_printer.rb
@@ -195,14 +195,14 @@ module RubyProf
       @output.puts "<title>#{h title}</title>"
       print_css
       print_java_script
-      @output.puts '</head><body>'
+      @output.puts '</head><body><div style="display: inline-block;">'
       print_title_bar
       print_commands
       print_help
     end
 
     def print_footer
-      @output.puts '<div id="sentinel"></div></body></html>'
+      @output.puts '<div id="sentinel"></div></div></body></html>'
     end
 
     def print_css


### PR DESCRIPTION
Fix the call stack printer so that when it is very wide, the background colors no longer cut off at the original width of the browser window.

Before: 

![Screen Shot 2013-02-14 at 2 16 21 PM](https://f.cloud.github.com/assets/23479/158342/8319f296-76e3-11e2-89be-f0c3e6b44568.png)

:sob:

After: 

![Screen Shot 2013-02-14 at 2 16 53 PM](https://f.cloud.github.com/assets/23479/158343/8b6b1a10-76e3-11e2-8b4f-cc5333f7d34b.png)

:heart_eyes: 

Checked in Chrome, Firefox, and Safari on MacOS.  

:thumbsup:?
