### PR TITLE
-lrt is not needed in OpenBSD.

### DIFF
--- a/ext/ruby_prof/extconf.rb
+++ b/ext/ruby_prof/extconf.rb
@@ -41,7 +41,7 @@ end
 # end
 
 require 'rubygems'
-unless Gem.win_platform? || RUBY_PLATFORM =~ /darwin/
+unless Gem.win_platform? || RUBY_PLATFORM =~ /(darwin|openbsd)/
   $LDFLAGS += " -lrt" # for clock_gettime
 end
 add_define("RUBY_VERSION", RUBY_VERSION.gsub('.', ''))


### PR DESCRIPTION
clock_gettime is in libc in OpenBSD. [1]

[1] http://www.openbsd.org/cgi-bin/cvsweb/ports/devel/ruby-prof/patches/patch-ext_ruby_prof_extconf_rb?rev=1.1
