### PR TITLE
Specify version of minitest. Tests do not run on 2.0 otherwise.

### DIFF
--- a/ruby-prof.gemspec
+++ b/ruby-prof.gemspec
@@ -55,7 +55,7 @@ EOF
   spec.required_ruby_version = '>= 1.8.7'
   spec.date = Time.now.strftime('%Y-%m-%d')
   spec.homepage = 'https://github.com/rdp/ruby-prof'
-  spec.add_development_dependency('minitest')
+  spec.add_development_dependency('minitest', '~> 4.0')
   spec.add_development_dependency('rake-compiler')
   spec.add_development_dependency('rdoc')
 end


### PR DESCRIPTION
I wasn't able to run unit tests on Ruby 2.0. I came across http://stackoverflow.com/questions/17461245/what-does-this-minitestunittestcase-warning-mean , suggesting that the error was due to using minitest 5.0 when the code was written for a previous version.

Without this change, no tests at all get run on Ruby 2.0.

Edit: actually, looks like the problem does not involve Ruby 2.0. It looks like it's just which version of minitest is being used.
