### PR TITLE
Fix CPU time measurement

### DIFF
--- a/ext/ruby_prof/rp_measure_cpu_time.c
+++ b/ext/ruby_prof/rp_measure_cpu_time.c
@@ -88,7 +88,7 @@ static unsigned long long get_cpu_frequency()
         cpu_frequency = cpu_frequency_struct.QuadPart;
     }
 
-    cpu_frequency = cpu_frequency_struct;
+    return cpu_frequency;
 }
 
 static double


### PR DESCRIPTION
`RubyProf::Measure::CpuTime.measure` is currently quite inefficient (it spends 500ms performing a bogomips-like estimation of CPU frequency) and inaccurate (CPU frequency is often dynamic these days).

This pull request changes it to use `getrusage` on non-Windows platforms.

Before:

```
λ time ruby -Ilib -rruby-prof -e 'puts RubyProf::Measure::CpuTime.measure'
17110.88256059947

real    0m0.562s
user    0m0.051s
sys     0m0.009s
```

After:

```
λ time ruby -Ilib -rruby-prof -e 'puts RubyProf::Measure::CpuTime.measure'
0.053457

real    0m0.059s
user    0m0.049s
sys     0m0.008s
```
