### PR TITLE
just use RUBY_ENGINE != 'ruby'

### DIFF
--- a/ext/ruby_prof/extconf.rb
+++ b/ext/ruby_prof/extconf.rb
@@ -5,6 +5,11 @@ if RUBY_VERSION < "1.9.3"
   exit(1)
 end
 
+if RUBY_ENGINE != "ruby"
+  STDERR.puts("\nThis gem is an MRI-specific gem and does not have any support for #{RUBY_ENGINE}\n")
+  exit(1)
+end
+
 # standard ruby methods
 have_func("rb_gc_stat")
 have_func("rb_gc_count")


### PR DESCRIPTION
MRI >= 1.9 should set this to 'ruby' correctly.

This will catch jruby, macruby, rbx, maglev, ironruby, cardinal and
any other non-MRI ruby out there which this gem does not support.