### PR TITLE
Allow for compilation of rp_measure_cpu_time.c with non-gnu-C

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -158,7 +158,7 @@ So to profile Rails:
 1. Create a new profile.rb environment. Make sure to turn on
    <tt>cache_classes</tt> and
    <tt>cache_template_loading</tt>. Otherwise your profiling results
-   will be overwhelemed by the time Rails spends loading required
+   will be overwhelmed by the time Rails spends loading required
    files. You should likely turn off caching.
 
 2. Add the ruby-prof to your gemfile:


### PR DESCRIPTION
Open conditional in rp_measure_cpu_time.c to accept non-gnu-c in addition.

Previously failing on AIX 6.1.
Before:
```
bash-4.2# gmake
compiling rp_measure_cpu_time.c
"rp_measure_cpu_time.c", line 103.24: 1506-045 (S) Undeclared identifier measure_cpu_time.
Makefile:224: recipe for target 'rp_measure_cpu_time.o' failed
gmake: *** [rp_measure_cpu_time.o] Error 1
bash-4.2# gmake clean
bash-4.2# gmake
compiling rp_call_info.c
compiling rp_measure.c
compiling rp_measure_allocations.c
compiling rp_measure_cpu_time.c
"rp_measure_cpu_time.c", line 103.24: 1506-045 (S) Undeclared identifier measure_cpu_time.
Makefile:224: recipe for target 'rp_measure_cpu_time.o' failed
gmake: *** [rp_measure_cpu_time.o] Error 1
```

After:
```
bash-4.2# gmake
compiling rp_measure_cpu_time.c
compiling rp_measure_gc_runs.c
compiling rp_measure_gc_time.c
compiling rp_measure_memory.c
compiling rp_measure_process_time.c
compiling rp_measure_wall_time.c
compiling rp_method.c
compiling rp_stack.c
compiling rp_thread.c
compiling ruby_prof.c
linking shared-object ruby_prof.so
```

/cc @scotthain @schisamo