### PR TITLE
Correct some mistakes in comments

### DIFF
--- a/bin/ruby-prof
+++ b/bin/ruby-prof
@@ -102,8 +102,8 @@ module RubyProf
         opts.on('--mode=measure_mode',
                 [:process, :wall, :cpu, :allocations, :memory, :gc_runs, :gc_time],
                 'Select what ruby-prof should measure:',
-                '  process - Process time (default).',
-                '  wall - Wall time.',
+                '  wall - Wall time (default).',
+                '  process - Process time.',
                 '  cpu - CPU time (Pentium and PowerPCs only).',
                 '  allocations - Object allocations (requires patched Ruby interpreter).',
                 '  memory - Allocated memory in KB (requires patched Ruby interpreter).',
@@ -111,10 +111,10 @@ module RubyProf
                 '  gc_time - Time spent in garbage collection (requires patched Ruby interpreter).') do |measure_mode|
 
           case measure_mode
-          when :process
-            options.measure_mode = RubyProf::PROCESS_TIME
           when :wall
             options.measure_mode = RubyProf::WALL_TIME
+          when :process
+            options.measure_mode = RubyProf::PROCESS_TIME
           when :cpu
             options.measure_mode = RubyProf::CPU_TIME
           when :allocations

--- a/lib/ruby-prof/compatibility.rb
+++ b/lib/ruby-prof/compatibility.rb
@@ -40,8 +40,8 @@ module RubyProf
   #
   # Returns what ruby-prof is measuring.  Valid values include:
   #
-  # *RubyProf::PROCESS_TIME - Measure process time.  This is default.  It is implemented using the clock functions in the C Runtime library.
-  # *RubyProf::WALL_TIME - Measure wall time using gettimeofday on Linx and GetLocalTime on Windows
+  # *RubyProf::WALL_TIME - Measure wall time using gettimeofday on Linx and GetLocalTime on Windows.  This is default.
+  # *RubyProf::PROCESS_TIME - Measure process time.  It is implemented using the clock functions in the C Runtime library.
   # *RubyProf::CPU_TIME - Measure time using the CPU clock counter.  This mode is only supported on Pentium or PowerPC platforms.
   # *RubyProf::ALLOCATIONS - Measure object allocations.  This requires a patched Ruby interpreter.
   # *RubyProf::MEMORY - Measure memory size.  This requires a patched Ruby interpreter.
@@ -57,8 +57,8 @@ module RubyProf
   #
   # Specifies what ruby-prof should measure.  Valid values include:
   #
-  # *RubyProf::PROCESS_TIME - Measure process time.  This is default.  It is implemented using the clock functions in the C Runtime library.
-  # *RubyProf::WALL_TIME - Measure wall time using gettimeofday on Linx and GetLocalTime on Windows
+  # *RubyProf::WALL_TIME - Measure wall time using gettimeofday on Linx and GetLocalTime on Windows.  This is default.
+  # *RubyProf::PROCESS_TIME - Measure process time.  It is implemented using the clock functions in the C Runtime library.
   # *RubyProf::CPU_TIME - Measure time using the CPU clock counter.  This mode is only supported on Pentium or PowerPC platforms.
   # *RubyProf::ALLOCATIONS - Measure object allocations.  This requires a patched Ruby interpreter.
   # *RubyProf::MEMORY - Measure memory size.  This requires a patched Ruby interpreter.


### PR DESCRIPTION
The default value of the measure mode is `RubyProf::WALL_TIME`.

https://github.com/ruby-prof/ruby-prof/blob/master/lib/ruby-prof/compatibility.rb#L52
```ruby
def self.measure_mode
  @measure_mode ||= RubyProf::WALL_TIME
end
```

Correct some mistakes in comments.