### PR TITLE
Fixed null text node bug

### DIFF
--- a/lib/ruby-prof/assets/call_stack_printer.js.html
+++ b/lib/ruby-prof/assets/call_stack_printer.js.html
@@ -61,7 +61,7 @@
 
   function setThresholdLI(li, threshold) {
     var img = li.firstChild;
-    var text = img.nextSibling;
+    var text = img.nextSibling.firstChild;
     var ul = findUlChild(li);
 
     var visible = aboveThreshold(text.nodeValue, threshold) ? 1 : 0;


### PR DESCRIPTION
This fixes a bug I noticed: `Uncaught TypeError: Cannot read property 'match' of null` in method `aboveThreshold`, line `var match = text.match(/\d+[.,]\d+/);`. Checked in Chrome 47.0.2526.106.