### PR TITLE
Performance tunings for root? checks

### DIFF
--- a/ext/ruby_prof/rp_call_info.c
+++ b/ext/ruby_prof/rp_call_info.c
@@ -291,6 +291,20 @@ prof_call_info_set_parent(VALUE self, VALUE new_parent)
     return prof_call_info_parent(self);
 }
 
+/* call-seq:
+   root? -> boolean
+
+Returns true if the call_info has no parent.*/
+static VALUE
+prof_call_info_root(VALUE self)
+{
+    prof_call_info_t *result = prof_get_call_info(self);
+    if (result->parent)
+      return Qfalse;
+    else
+      return Qtrue;
+}
+
 static int
 prof_call_info_collect_children(st_data_t key, st_data_t value, st_data_t result)
 {
@@ -392,6 +406,7 @@ void rp_init_call_info()
     rb_undef_method(CLASS_OF(cCallInfo), "new");
     rb_define_method(cCallInfo, "parent", prof_call_info_parent, 0);
     rb_define_method(cCallInfo, "parent=", prof_call_info_set_parent, 1);
+    rb_define_method(cCallInfo, "root?", prof_call_info_root, 0);
     rb_define_method(cCallInfo, "children", prof_call_info_children, 0);
     rb_define_method(cCallInfo, "target", prof_call_info_target, 0);
     rb_define_method(cCallInfo, "called", prof_call_info_called, 0);

--- a/ext/ruby_prof/rp_method.c
+++ b/ext/ruby_prof/rp_method.c
@@ -394,6 +394,25 @@ prof_method_call_infos(VALUE self)
 	return method->call_infos->object;
 }
 
+/* call-seq:
+   root? -> boolean
+
+Returns true if all the child call_infos have no parent.*/
+static VALUE
+prof_method_root(VALUE self)
+{
+    prof_method_t *method = get_prof_method(self);
+    prof_call_info_t **call_info;
+
+    for(call_info=method->call_infos->start; call_info < method->call_infos->ptr; call_info++)
+    {
+      if ( (*call_info)->parent ) {
+        return Qfalse;
+      }
+    }
+    return Qtrue;
+}
+
 void rp_init_method_info()
 {
     /* MethodInfo */
@@ -408,4 +427,5 @@ void rp_init_method_info()
     rb_define_method(cMethodInfo, "source_file", prof_method_source_file,0);
     rb_define_method(cMethodInfo, "line", prof_method_line, 0);
     rb_define_method(cMethodInfo, "call_infos", prof_method_call_infos, 0);
+    rb_define_method(cMethodInfo, "root?", prof_method_root, 0);
 }

--- a/lib/ruby-prof/call_info.rb
+++ b/lib/ruby-prof/call_info.rb
@@ -11,13 +11,13 @@ module RubyProf
 
     attr_reader :recursive
 
-    def detect_recursion(visited_methods = Hash.new(0))
-      @recursive = (visited_methods[target] += 1) > 1
+    def detect_recursion(visited_methods = Hash.new(0).compare_by_identity)
+      target_method = self.target
+      @recursive = (visited_methods[target_method] += 1) > 1
       children.each do |child|
         child.detect_recursion(visited_methods)
       end
-      visited_methods.delete(target) if (visited_methods[target] -= 1) == 0
-      return @recursive
+      visited_methods.delete(target_method) if (visited_methods[target_method] -= 1) == 0
     end
 
     def children_time

--- a/lib/ruby-prof/call_info.rb
+++ b/lib/ruby-prof/call_info.rb
@@ -45,10 +45,6 @@ module RubyProf
       end
     end
 
-    def root?
-      self.parent.nil?
-    end
-
     def descendent_of(other)
       p = self.parent
       while p && p != other && p.depth > other.depth

--- a/lib/ruby-prof/method_info.rb
+++ b/lib/ruby-prof/method_info.rb
@@ -70,14 +70,6 @@ module RubyProf
       @min_depth ||= call_infos.map(&:depth).min
     end
 
-    def root?
-      @root ||= begin
-        call_infos.find do |call_info|
-          not call_info.root?
-        end.nil?
-      end
-    end
-
     def recursive?
       (@recursive ||= call_infos.detect(&:recursive) ? :true : :false) == :true
     end

--- a/lib/ruby-prof/thread.rb
+++ b/lib/ruby-prof/thread.rb
@@ -1,13 +1,11 @@
 module RubyProf
   class Thread
     def top_methods
-      self.methods.select do |method_info|
-        method_info.call_infos.detect(&:root?)
-      end
+      self.methods.select(&:root?)
     end
 
     def top_call_infos
-      top_methods.map(&:call_infos).flatten.select(&:root?)
+      top_methods.flat_map(&:call_infos).keep_if(&:root?)
     end
 
     # This method detect recursive calls in the call tree of a given thread
@@ -17,13 +15,8 @@ module RubyProf
     end
 
     def total_time
-      self.top_methods.inject(0) do |sum, method_info|
-        method_info.call_infos.each do |call_info|
-          if call_info.parent.nil?
-            sum += call_info.total_time
-          end
-        end
-        sum
+      @total_time = self.top_call_infos.inject(0) do |sum, call_info|
+        sum += call_info.total_time
       end
     end
   end


### PR DESCRIPTION
This PR moves the `root?` check for CallInfo and MethodInfo objects into C code and tunes up some of the methods that check for root methods and for recursion.

The performance gain on profiling varies depending on the complexity of what is being profiled but can range from **25-50%** faster.

I've created a benchmark script (https://gist.github.com/dgynn/bf1983d28f6b01cab6e6) which is not included in the PR. This script profiles a simple ActiveRecord transaction against an in-memory database.

```
# Before
Calculating -------------------------------------
Unprofiled post create
                        878.695  (± 3.0%) i/s -      4.450k
Profiled post create     56.998  (± 7.0%) i/s -    285.000 

# After
Calculating -------------------------------------
Unprofiled post create
                        872.693  (± 2.5%) i/s -      4.437k
Profiled post create     74.454  (± 8.1%) i/s -    371.000 

# 74.454/56.998 = 1.30x faster
```

Memory allocation is only slightly improved by creating a few less arrays. Most of the memory allocated by ruby-prof is in CallInfo records and can not be reduced.

This is my first C extension modification so let me know if that looks OK.