### PR TITLE
Use autoload for printers

### DIFF
--- a/lib/ruby-prof.rb
+++ b/lib/ruby-prof.rb
@@ -9,27 +9,28 @@ rescue LoadError
 end
 
 require 'ruby-prof/version'
-require 'ruby-prof/aggregate_call_info'
 require 'ruby-prof/call_info'
-require 'ruby-prof/call_info_visitor'
 require 'ruby-prof/compatibility'
 require 'ruby-prof/method_info'
 require 'ruby-prof/profile'
 require 'ruby-prof/rack'
 require 'ruby-prof/thread'
 
-require 'ruby-prof/printers/abstract_printer'
-require 'ruby-prof/printers/call_info_printer'
-require 'ruby-prof/printers/call_stack_printer'
-require 'ruby-prof/printers/call_tree_printer'
-require 'ruby-prof/printers/dot_printer'
-require 'ruby-prof/printers/flat_printer'
-require 'ruby-prof/printers/flat_printer_with_line_numbers'
-require 'ruby-prof/printers/graph_html_printer'
-require 'ruby-prof/printers/graph_printer'
-require 'ruby-prof/printers/multi_printer'
-
 module RubyProf
+  autoload :AggregateCallInfo, 'ruby-prof/aggregate_call_info'
+  autoload :CallInfoVisitor, 'ruby-prof/call_info_visitor'
+
+  autoload :AbstractPrinter, 'ruby-prof/printers/abstract_printer'
+  autoload :CallInfoPrinter, 'ruby-prof/printers/call_info_printer'
+  autoload :CallStackPrinter, 'ruby-prof/printers/call_stack_printer'
+  autoload :CallTreePrinter, 'ruby-prof/printers/call_tree_printer'
+  autoload :DotPrinter, 'ruby-prof/printers/dot_printer'
+  autoload :FlatPrinter, 'ruby-prof/printers/flat_printer'
+  autoload :FlatPrinterWithLineNumbers, 'ruby-prof/printers/flat_printer_with_line_numbers'
+  autoload :GraphHtmlPrinter, 'ruby-prof/printers/graph_html_printer'
+  autoload :GraphPrinter, 'ruby-prof/printers/graph_printer'
+  autoload :MultiPrinter, 'ruby-prof/printers/multi_printer'
+
   # Checks if the user specified the clock mode via
   # the RUBY_PROF_MEASURE_MODE environment variable
   def self.figure_measure_mode

--- a/lib/ruby-prof/profile.rb
+++ b/lib/ruby-prof/profile.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 
-require 'set'
 module RubyProf
   class Profile
     # This method gets called once profiling has been completed


### PR DESCRIPTION
Improve startup time and memory by not loading printers that never get used.