### PR TITLE
Dont use rubygems on extconf

### DIFF
--- a/ext/ruby_prof/extconf.rb
+++ b/ext/ruby_prof/extconf.rb
@@ -38,7 +38,12 @@ def add_define(name, value = nil)
   end
 end
 
-if !Gem.win_platform? && RUBY_PLATFORM !~ /(darwin|openbsd)/
+require 'rbconfig'
+def windows?
+  RbConfig::CONFIG['host_os'] =~ /mswin|mingw/
+end
+
+if !windows? && RUBY_PLATFORM !~ /(darwin|openbsd)/
   $LDFLAGS += " -lrt" # for clock_gettime
 end
 add_define("RUBY_VERSION", RUBY_VERSION.gsub('.', ''))


### PR DESCRIPTION
extconf.rb fail to run when disabling rubygems: 
`RUBYOPT='--disable-gems' rake`

Instead of requiring rubygems here, we could just use rbconfig instead.