### PR TITLE
Making it possible to aggregate several requests in the Rack middleware

### DIFF
--- a/lib/ruby-prof/rack.rb
+++ b/lib/ruby-prof/rack.rb
@@ -5,43 +5,161 @@ module Rack
   class RubyProf
     def initialize(app, options = {})
       @app = app
-      @options = options
-      @options[:min_percent] ||= 1
 
-      @tmpdir = options[:path] || Dir.tmpdir
-      FileUtils.mkdir_p(@tmpdir)
+      options[:min_percent] ||= 1
 
-      @printer_klasses = @options[:printers]  || {::RubyProf::FlatPrinter => 'flat.txt',
-                                                  ::RubyProf::GraphPrinter => 'graph.txt',
-                                                  ::RubyProf::GraphHtmlPrinter => 'graph.html',
-                                                  ::RubyProf::CallStackPrinter => 'call_stack.html'}
+      options[:path] ||= Dir.tmpdir
+      FileUtils.mkdir_p(options[:path])
 
       @skip_paths = options[:skip_paths] || [%r{^/assets}, %r{\.(css|js|png|jpeg|jpg|gif)$}]
       @only_paths = options[:only_paths]
+
+      @max_requests = options[:max_requests]
+
+      @options = options
     end
 
     def call(env)
       request = Rack::Request.new(env)
 
       if should_profile?(request.path)
+        profiler.resume
         begin
-          result = nil
-          data = ::RubyProf::Profile.profile(profiling_options) do
-            result = @app.call(env)
-          end
-
-          path = request.path.gsub('/', '-')
-          path.slice!(0)
-
-          print(data, path)
-          result
+          result = @app.call(env)
+        ensure
+          profiler.pause
         end
+
+        if profiler.max_requests_reached?
+          prefix = if aggregate_requests?
+              nil
+            else
+              request.path.gsub('/', '-')[1..-1]
+            end
+
+          profiler.print!(prefix)
+          delete_profiler!
+        end
+
+        result
       else
         @app.call(env)
       end
     end
 
     private
+
+    class RackProfiler
+      def initialize(options)
+        @options = options
+
+        @profile = ::RubyProf::Profile.new(profiling_options)
+        @profile.start
+        @profile.pause
+
+        @printer_klasses = options[:printers] || default_printers
+
+        @tmpdir = options[:path]
+
+        @max_requests = options[:max_requests] || 1
+        @requests_count = 0
+
+        @printed = false
+        # if running across multiple requests, we want to make sure that the
+        # ongoing profile is not lost if the process shuts down before the
+        # max request count is reached
+        ObjectSpace.define_finalizer(self, proc { print! })
+      end
+
+      def resume
+        @profile.resume
+      end
+
+      def pause
+        @profile.pause
+        @requests_count += 1
+      end
+
+      def max_requests_reached?
+        @requests_count >= @max_requests
+      end
+
+      def print!(prefix = nil)
+        return false if @printed || @requests_count == 0
+
+        data = @profile.stop
+
+        prefix ||= "multi-requests-#{@requests_count}"
+
+        @printer_klasses.each do |printer_klass, base_name|
+          printer = printer_klass.new(data)
+
+          if base_name.respond_to?(:call)
+            base_name = base_name.call
+          end
+
+          if printer_klass == ::RubyProf::MultiPrinter \
+              || printer_klass == ::RubyProf::CallTreePrinter
+            printer.print(@options.merge(:profile => "#{prefix}-#{base_name}"))
+          else
+            file_name = ::File.join(@tmpdir, "#{prefix}-#{base_name}")
+            ::File.open(file_name, 'wb') do |file|
+              printer.print(file, @options)
+            end
+          end
+        end
+
+        @printed = true
+      end
+
+      private
+
+      def profiling_options
+        options = {}
+        options[:measure_mode] = ::RubyProf.measure_mode
+        options[:exclude_threads] =
+          if @options[:ignore_existing_threads]
+            Thread.list.select{|t| t != Thread.current}
+          else
+            ::RubyProf.exclude_threads
+          end
+        if @options[:request_thread_only]
+          options[:include_threads] = [Thread.current]
+        end
+        if @options[:merge_fibers]
+          options[:merge_fibers] = true
+        end
+        options
+      end
+
+      def default_printers
+        {::RubyProf::FlatPrinter => 'flat.txt',
+         ::RubyProf::GraphPrinter => 'graph.txt',
+         ::RubyProf::GraphHtmlPrinter => 'graph.html',
+         ::RubyProf::CallStackPrinter => 'call_stack.html'}
+      end
+    end
+
+    def profiler
+      if aggregate_requests?
+        @@_shared_profiler ||= RackProfiler.new(@options)
+      else
+        @_profiler ||= RackProfiler.new(@options)
+      end
+    end
+
+    def delete_profiler!
+      if aggregate_requests?
+        @@_shared_profiler.print! if @@_shared_profiler
+        @@_shared_profiler = nil
+      else
+        @_profiler = nil
+      end
+    end
+
+    def aggregate_requests?
+      !@max_requests.nil?
+    end
 
     def should_profile?(path)
       return false if paths_match?(path, @skip_paths)
@@ -51,45 +169,6 @@ module Rack
 
     def paths_match?(path, paths)
       paths.any? { |skip_path| skip_path =~ path }
-    end
-
-    def profiling_options
-      options = {}
-      options[:measure_mode] = ::RubyProf.measure_mode
-      options[:exclude_threads] =
-        if @options[:ignore_existing_threads]
-          Thread.list.select{|t| t != Thread.current}
-        else
-          ::RubyProf.exclude_threads
-        end
-      if @options[:request_thread_only]
-        options[:include_threads] = [Thread.current]
-      end
-      if @options[:merge_fibers]
-        options[:merge_fibers] = true
-      end
-      options
-    end
-
-    def print(data, path)
-      @printer_klasses.each do |printer_klass, base_name|
-        printer = printer_klass.new(data)
-
-        if base_name.respond_to?(:call)
-          base_name = base_name.call
-        end
-
-        if printer_klass == ::RubyProf::MultiPrinter
-          printer.print(@options.merge(:profile => "#{path}-#{base_name}"))
-        elsif printer_klass == ::RubyProf::CallTreePrinter
-          printer.print(@options.merge(:profile => "#{path}-#{base_name}"))
-        else
-          file_name = ::File.join(@tmpdir, "#{path}-#{base_name}")
-          ::File.open(file_name, 'wb') do |file|
-            printer.print(file, @options)
-          end
-        end
-      end
     end
   end
 end

--- a/test/rack_test.rb
+++ b/test/rack_test.rb
@@ -24,6 +24,16 @@ module Rack
   end
 end
 
+module Rack
+  class RubyProf
+    attr_reader :_profiler
+
+    def public_delete_profiler!
+      delete_profiler!
+    end
+  end
+end
+
 class RackTest < TestCase
   def test_create_print_path
     path = Dir.mktmpdir
@@ -89,5 +99,59 @@ class RackTest < TestCase
 
     file_path = ::File.join(path, 'path-to-resource.json-dynamic.txt')
     assert(File.exist?(file_path))
+  end
+
+  def test_works_for_multiple_requests
+    path = Dir.mktmpdir
+
+    adapter = Rack::RubyProf.new(FakeRackApp.new, :path => path, :max_requests => 2)
+
+    # make a 1st request, and check that this didn't create any files
+    adapter.call(:fake_env)
+    assert(Dir["#{path}/*"].empty?)
+
+    # now a second request should create all the expected files
+    adapter.call(:fake_env)
+    %w(flat.txt graph.txt graph.html call_stack.html).each do |base_name|
+      file_path = ::File.join(path, "multi-requests-2-#{base_name}")
+      assert(File.exist?(file_path))
+    end
+
+    # let's clean up
+    FileUtils.rm_rf(Dir["#{path}/*"])
+
+    # and do the same again for the next 2 requests
+    adapter.call(:fake_env)
+    assert(Dir["#{path}/*"].empty?)
+
+    adapter.call(:fake_env)
+    %w(flat.txt graph.txt graph.html call_stack.html).each do |base_name|
+      file_path = ::File.join(path, "multi-requests-2-#{base_name}")
+      assert(File.exist?(file_path))
+    end
+  end
+
+  def test_tries_to_print_results_if_shut_down_before_max_requests_reached
+    path = Dir.mktmpdir
+
+    adapter = Rack::RubyProf.new(FakeRackApp.new, :path => path, :max_requests => 100)
+
+    # make a 1st request, and check that this didn't create any files
+    adapter.call(:fake_env)
+    assert(Dir["#{path}/*"].empty?)
+
+    adapter.public_delete_profiler!
+
+    %w(flat.txt graph.txt graph.html call_stack.html).each do |base_name|
+      file_path = ::File.join(path, "multi-requests-1-#{base_name}")
+      assert(File.exist?(file_path))
+    end
+  end
+
+  def test_it_uses_separate_profilers_if_not_aggregating_multiple_requests
+    adapter1 = Rack::RubyProf.new(FakeRackApp.new)
+    adapter2 = Rack::RubyProf.new(FakeRackApp.new)
+
+    assert(adapter1.object_id != adapter2.object_id)
   end
 end


### PR DESCRIPTION
If using the Rack middleware to process a lot of requests, it can be quite
a pain to make sense of the sheer volume of files generated (one per request).

This patch adds a new `:max_requests` to the middleware, which will then
starts aggregating profiles across requests and will only dump the result file
when it has profiled `:max_requests` requests or when the current process shuts
down, whichever happens first.

Kept total backward compatibility.

Added tests on the new feature.
