### PR TITLE
Minor cleanup and KCacheGrind friendlier naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ examples2
 .rvmrc
 Gemfile.lock
 /profile.callgrind.out.*
+*.gem
+.ruby-version

--- a/ext/ruby_prof/extconf.rb
+++ b/ext/ruby_prof/extconf.rb
@@ -10,6 +10,9 @@ if RUBY_VERSION < "1.9.3"
   exit(1)
 end
 
+# For the love of bitfields...
+$CFLAGS += ' -std=c99'
+
 # standard ruby methods
 have_func("rb_gc_stat")
 have_func("rb_gc_count")

--- a/ext/ruby_prof/rp_method.c
+++ b/ext/ruby_prof/rp_method.c
@@ -29,7 +29,7 @@ figure_singleton_name(VALUE klass)
     if (BUILTIN_TYPE(attached) == T_CLASS)
     {
         result = rb_str_new2("<Class::");
-        rb_str_append(result, rb_inspect(attached));
+        rb_str_append(result, rb_class_name(attached));
         rb_str_cat2(result, ">");
     }
 
@@ -37,7 +37,7 @@ figure_singleton_name(VALUE klass)
     else if (BUILTIN_TYPE(attached) == T_MODULE)
     {
         result = rb_str_new2("<Module::");
-        rb_str_append(result, rb_inspect(attached));
+        rb_str_append(result, rb_class_name(attached));
         rb_str_cat2(result, ">");
     }
 
@@ -49,7 +49,7 @@ figure_singleton_name(VALUE klass)
            unknown method errors. */
         VALUE super = rb_class_superclass(klass);
         result = rb_str_new2("<Object::");
-        rb_str_append(result, rb_inspect(super));
+        rb_str_append(result, rb_class_name(super));
         rb_str_cat2(result, ">");
     }
 
@@ -58,7 +58,7 @@ figure_singleton_name(VALUE klass)
        objects test case). */
     else
     {
-        result = rb_inspect(klass);
+        result = rb_any_to_s(klass);
     }
 
     return result;
@@ -75,7 +75,7 @@ klass_name(VALUE klass)
     }
     else if (BUILTIN_TYPE(klass) == T_MODULE)
     {
-        result = rb_inspect(klass);
+        result = rb_class_name(klass);
     }
     else if (BUILTIN_TYPE(klass) == T_CLASS && FL_TEST(klass, FL_SINGLETON))
     {
@@ -83,7 +83,7 @@ klass_name(VALUE klass)
     }
     else if (BUILTIN_TYPE(klass) == T_CLASS)
     {
-        result = rb_inspect(klass);
+        result = rb_class_name(klass);
     }
     else
     {

--- a/ext/ruby_prof/rp_method.c
+++ b/ext/ruby_prof/rp_method.c
@@ -228,6 +228,9 @@ prof_method_free(prof_method_t* method)
 void
 prof_method_mark(prof_method_t *method)
 {
+    if (method->key->klass)
+        rb_gc_mark(method->key->klass);
+
     if (method->resolved_klass)
         rb_gc_mark(method->resolved_klass);
 

--- a/ext/ruby_prof/rp_method.h
+++ b/ext/ruby_prof/rp_method.h
@@ -26,6 +26,8 @@ typedef struct
     prof_method_key_t *key;                 /* Method key */
     const char *source_file;                /* The method's source file */
     int line;                               /* The method's line number. */
+    VALUE resolved_klass;                   /* The method's resolved class */
+    int flags;                              /* The method's resolved class relationship */
     struct prof_call_infos_t *call_infos;   /* Call info objects for this method */
     VALUE object;                           /* Cached ruby object */
 } prof_method_t;

--- a/ext/ruby_prof/rp_method.h
+++ b/ext/ruby_prof/rp_method.h
@@ -16,20 +16,34 @@ typedef struct
     st_index_t key;                         /* Cache calculated key */
 } prof_method_key_t;
 
+/* Source relation bit offsets. */
+enum {
+    kModuleIncludee = 0,                    /* Included module */
+    kModuleSingleton,                       /* Singleton class of a module */
+    kObjectSingleton                        /* Singleton class of an object */
+};
 
 /* Forward declaration, see rp_call_info.h */
 struct prof_call_infos_t;
 
 /* Profiling information for each method. */
-typedef struct 
+/* Eliminated methods have no call_infos, source_file, or source_module. */
+typedef struct
 {
-    prof_method_key_t *key;                 /* Method key */
-    const char *source_file;                /* The method's source file */
-    int line;                               /* The method's line number. */
-    VALUE resolved_klass;                   /* The method's resolved class */
-    int flags;                              /* The method's resolved class relationship */
-    struct prof_call_infos_t *call_infos;   /* Call info objects for this method */
+    /* Hot */
+
+    prof_method_key_t *key;                 /* Table key */
+    struct prof_call_infos_t *call_infos;   /* Call infos */
+
+    /* Cold */
+
     VALUE object;                           /* Cached ruby object */
+    VALUE source_klass;                     /* Source class */
+    const char *source_file;                /* Source file */
+    int line;                               /* Line number */
+
+    unsigned int resolved : 1;              /* Source resolved? */
+    unsigned int relation : 3;              /* Source relation bits */
 } prof_method_t;
 
 void rp_init_method_info(void);

--- a/lib/ruby-prof/printers/call_tree_printer.rb
+++ b/lib/ruby-prof/printers/call_tree_printer.rb
@@ -110,7 +110,7 @@ module RubyProf
     def print_method(output, method)
       # Print out the file and method name
       output << "fl=#{file(method)}\n"
-      output << "fn=#{method_name(method)}\n"
+      output << "fn=#{method.calltree_name}\n"
 
       # Now print out the function line number and its self time
       output << "#{method.line} #{convert(method.self_time)}\n"
@@ -118,7 +118,7 @@ module RubyProf
       # Now print out all the children methods
       method.children.each do |callee|
         output << "cfl=#{file(callee.target)}\n"
-        output << "cfn=#{method_name(callee.target)}\n"
+        output << "cfn=#{callee.target.calltree_name}\n"
         output << "calls=#{callee.called} #{callee.line}\n"
 
         # Print out total times here!

--- a/test/no_method_class_test.rb
+++ b/test/no_method_class_test.rb
@@ -10,6 +10,6 @@ end
 
 methods = result.threads.first.methods
 global_method = methods.sort_by {|method| method.full_name}.first
-if global_method.full_name != 'Global#[No method]'
+if global_method.full_name != 'Kernel#sleep'
   raise(RuntimeError, "Wrong method name.  Expected: Global#[No method].  Actual: #{global_method.full_name}")
 end

--- a/test/printers_test.rb
+++ b/test/printers_test.rb
@@ -120,7 +120,7 @@ class PrintersTest < TestCase
     main_output_file_name = File.join(RubyProf.tmpdir, "lolcat.callgrind.out.#{$$}")
     assert(File.exist?(main_output_file_name))
     output = File.read(main_output_file_name)
-    assert_match(/fn=Object#find_primes/i, output)
+    assert_match(/fn=Object::find_primes/i, output)
     assert_match(/events: wall_time/i, output)
     refute_match(/d\d\d\d\d\d/, output) # old bug looked [in error] like Object::run_primes(d5833116)
   end


### PR DESCRIPTION
Last year, we at Airbnb started encountering problems that required serious profiling work.  Luckily, `ruby-prof` was there to help.  While using it, we iterated on internal patches to get the results we desired.  The time has come to offer these up in the hopes that they may be useful to others.
### This PR

This is the first patchset in the series and is the base on which we built the other patches.  This fixes a few bugs we encountered with GC, enables C99 support, begins making some changes to MethodInfo that will come into play later, and tweaks the way methods are named for callgrind output.

KCacheGrind is designed for C++ and many of its features expect C++ style names.  Faking Ruby names into C++ allows the class groupings to work, for instance.  This requires `Foo::Bar#baz` to be rendered as `Foo/Bar::baz` and `Foo::Bar.baz` to become `Foo/Bar::^baz`.  
### The Other PRs

The other patches work around some issues we experienced with some of our more pathological code and work around some performance issues in post processing.  We're working to have profiles for basically everything all the time.  We're taking profiles of our app as part of our deploy system, so the faster we can get the results, the faster they can be used to verify behavior.

The next patch (https://github.com/ruby-prof/ruby-prof/pull/201) moves the detection of recursive calls into the profiler where we already have the appropriate context.  This avoids iterating recursively over call_infos in ruby, which was causing us to overflow the ruby stack.  This also avoids transforming the lightweight call_info structs into full ruby objects.

After that, we have a patch (https://github.com/ruby-prof/ruby-prof/pull/202) that optimizes method elimination by allowing the set of exclusions to be set prior to the start of the profiling, which allows exclusions to be computed efficiently while the profiler is running.  It also includes a set of exclusions that we found to be rather helpful.  We make heavy use of method elimination because we weren't having a great time making sense of:

![Hash#each party](https://d3vv6lp55qjaqc.cloudfront.net/items/0l3q453G1o2F2I2N0l0x/Image%202016-09-15%20at%203.58.54%20PM.png)

From there, we implemented a FastCallTreePrinter in C to cut down on the printing time and avoid turning the C structs into Ruby objects.  We also expanded calling contexts in the output to display recursion in an easier way for us to understand.  This produces acyclic calling context graphs.  We initially implemented the acyclic calling context in Ruby, so we can also show that to better explain what's going on.  I'll push out a PR for this once we've made some determinations around the recursion detection and method elimination.

We also have a Flame Graph printer implementation that may be of interest.  It's a bit more WIP, though we have been using it effectively internally.

We've been running thousands of profiles a day with these patches on our application code for the last several months.
### Performance

The big motivator was performance.  Here's the output of a partial benchmark of our application with different patches and configurations applied.

```
# No Profiler

Ran startup_1 in 25.7534
Ran health_check_1 in 0.5909
Ran api_request_1 in 1.0071
Ran api_request_2 in 0.1663
Ran api_request_3 in 0.1612
Ran web_request_1 in 0.8406
Ran web_request_2 in 0.3331
Ran web_request_3 in 0.3355
       34.95 real        29.39 user         4.83 sys

# Normal ruby-prof, no method elimination

Ran startup_1 in 39.0779
CallTree Printed startup_1 in 38.8305
Ran health_check_1 in 2.1724
CallTree Printed health_check_1 in 0.6217
Ran api_request_1 in 1.6901
CallTree Printed api_request_1 in 6.2656
Ran api_request_2 in 0.3136
CallTree Printed api_request_2 in 3.124
Ran api_request_3 in 0.3034
CallTree Printed api_request_3 in 3.0616
Ran web_request_1 in 1.7542
CallTree Printed web_request_1 in 8.9981
Ran web_request_2 in 0.727
CallTree Printed web_request_2 in 6.5484
Ran web_request_3 in 0.7873
CallTree Printed web_request_3 in 5.6912
      136.02 real       106.00 user        24.43 sys

# Normal ruby-prof, with method elimination

Ran startup_1 in 39.977
Eliminated methods in 29.710811853408813
CallTree Printed startup_1 in 23.4058
Ran health_check_1 in 1.9614
Eliminated methods in 0.9827449321746826
CallTree Printed health_check_1 in 0.371
Ran api_request_1 in 1.3887
Eliminated methods in 39.2588369846344
CallTree Printed api_request_1 in 3.5249
Ran api_request_2 in 0.29
Eliminated methods in 34.2704701423645
CallTree Printed api_request_2 in 2.0726
Ran api_request_3 in 0.326
Eliminated methods in 33.48537802696228
CallTree Printed api_request_3 in 2.5554
Ran web_request_1 in 1.3403
Eliminated methods in 35.51815676689148
CallTree Printed web_request_1 in 4.0794
Ran web_request_2 in 0.6563
Eliminated methods in 33.51047492027283
CallTree Printed web_request_2 in 4.1163
Ran web_request_3 in 0.5773
Eliminated methods in 33.727806091308594
CallTree Printed web_request_3 in 3.2598
      346.48 real       322.53 user        19.25 sys

# Patched with C Recursion Detection and C Method Elimination

Ran startup_1 in 34.5836
CallTree Printed startup_1 in 24.0047
Ran health_check_1 in 1.9761
CallTree Printed health_check_1 in 0.3595
Ran api_request_1 in 1.3652
CallTree Printed api_request_1 in 3.5098
Ran api_request_2 in 0.2698
CallTree Printed api_request_2 in 2.0452
Ran api_request_3 in 0.2682
CallTree Printed api_request_3 in 1.8847
Ran web_request_1 in 1.2476
CallTree Printed web_request_1 in 4.6494
Ran web_request_2 in 0.5839
CallTree Printed web_request_2 in 3.6305
Ran web_request_3 in 0.5609
CallTree Printed web_request_3 in 3.4074
       93.21 real        75.97 user        16.14 sys

# C Recursion, C Method Elimination, C FastCallTreePrinter

Ran startup_1 in 36.4022
CallTree Printed startup_1 in 3.4704
Ran health_check_1 in 1.9085
CallTree Printed health_check_1 in 0.1856
Ran api_request_1 in 1.3112
CallTree Printed api_request_1 in 1.543
Ran api_request_2 in 0.2723
CallTree Printed api_request_2 in 1.0085
Ran api_request_3 in 0.2515
CallTree Printed api_request_3 in 1.0083
Ran web_request_1 in 1.2896
CallTree Printed web_request_1 in 2.423
Ran web_request_2 in 0.5969
CallTree Printed web_request_2 in 2.0827
Ran web_request_3 in 0.5692
CallTree Printed web_request_3 in 1.9563
       62.98 real        55.99 user         5.84 sys
```

/cc @skaes @nelgau
