### PR TITLE
Detect recursive contexts during profiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ examples2
 .rvmrc
 Gemfile.lock
 /profile.callgrind.out.*
+*.gem
+.ruby-version

--- a/ext/ruby_prof/extconf.rb
+++ b/ext/ruby_prof/extconf.rb
@@ -10,6 +10,9 @@ if RUBY_VERSION < "1.9.3"
   exit(1)
 end
 
+# For the love of bitfields...
+$CFLAGS += ' -std=c99'
+
 # standard ruby methods
 have_func("rb_gc_stat")
 have_func("rb_gc_count")

--- a/ext/ruby_prof/rp_call_info.c
+++ b/ext/ruby_prof/rp_call_info.c
@@ -23,11 +23,16 @@ prof_call_info_create(prof_method_t* method, prof_call_info_t* parent)
     result->call_infos = call_info_table_create();
     result->children = Qnil;
 
-    result->called = 0;
     result->total_time = 0;
     result->self_time = 0;
     result->wait_time = 0;
+
+    result->called = 0;
+
+    result->recursive = 0;
+    result->depth = 0;
     result->line = 0;
+
     return result;
 }
 static void
@@ -160,6 +165,17 @@ prof_call_info_set_called(VALUE self, VALUE called)
     prof_call_info_t *result = prof_get_call_info(self);
     result->called = NUM2INT(called);
     return called;
+}
+
+/* call-seq:
+   recursive? -> boolean
+
+   Returns the true if this call info is a recursive invocation */
+static VALUE
+prof_call_info_recursive(VALUE self)
+{
+  prof_call_info_t *result = prof_get_call_info(self);
+  return result->recursive ? Qtrue : Qfalse;
 }
 
 /* call-seq:
@@ -402,6 +418,8 @@ void rp_init_call_info()
     rb_define_method(cCallInfo, "add_self_time", prof_call_info_add_self_time, 1);
     rb_define_method(cCallInfo, "wait_time", prof_call_info_wait_time, 0);
     rb_define_method(cCallInfo, "add_wait_time", prof_call_info_add_wait_time, 1);
+
+    rb_define_method(cCallInfo, "recursive?", prof_call_info_recursive, 0);
     rb_define_method(cCallInfo, "depth", prof_call_info_depth, 0);
     rb_define_method(cCallInfo, "line", prof_call_info_line, 0);
 }

--- a/ext/ruby_prof/rp_call_info.h
+++ b/ext/ruby_prof/rp_call_info.h
@@ -15,14 +15,19 @@ typedef struct prof_call_info_t
     prof_method_t *target; /* Use target instead of method to avoid conflict with Ruby method */
     struct prof_call_info_t *parent;
     st_table *call_infos;
-    int called;
-	int depth;
+
     double total_time;
     double self_time;
     double wait_time;
-    int line;
+
     VALUE object;
     VALUE children;
+
+    int called;
+
+    unsigned int recursive : 1;
+    unsigned int depth : 15;
+    unsigned int line : 16;
 } prof_call_info_t;
 
 /* Array of call_info objects */

--- a/ext/ruby_prof/rp_method.c
+++ b/ext/ruby_prof/rp_method.c
@@ -29,7 +29,7 @@ figure_singleton_name(VALUE klass)
     if (BUILTIN_TYPE(attached) == T_CLASS)
     {
         result = rb_str_new2("<Class::");
-        rb_str_append(result, rb_inspect(attached));
+        rb_str_append(result, rb_class_name(attached));
         rb_str_cat2(result, ">");
     }
 
@@ -37,7 +37,7 @@ figure_singleton_name(VALUE klass)
     else if (BUILTIN_TYPE(attached) == T_MODULE)
     {
         result = rb_str_new2("<Module::");
-        rb_str_append(result, rb_inspect(attached));
+        rb_str_append(result, rb_class_name(attached));
         rb_str_cat2(result, ">");
     }
 
@@ -49,7 +49,7 @@ figure_singleton_name(VALUE klass)
            unknown method errors. */
         VALUE super = rb_class_superclass(klass);
         result = rb_str_new2("<Object::");
-        rb_str_append(result, rb_inspect(super));
+        rb_str_append(result, rb_class_name(super));
         rb_str_cat2(result, ">");
     }
 
@@ -58,7 +58,7 @@ figure_singleton_name(VALUE klass)
        objects test case). */
     else
     {
-        result = rb_inspect(klass);
+        result = rb_any_to_s(klass);
     }
 
     return result;
@@ -75,7 +75,7 @@ klass_name(VALUE klass)
     }
     else if (BUILTIN_TYPE(klass) == T_MODULE)
     {
-        result = rb_inspect(klass);
+        result = rb_class_name(klass);
     }
     else if (BUILTIN_TYPE(klass) == T_CLASS && FL_TEST(klass, FL_SINGLETON))
     {
@@ -83,7 +83,7 @@ klass_name(VALUE klass)
     }
     else if (BUILTIN_TYPE(klass) == T_CLASS)
     {
-        result = rb_inspect(klass);
+        result = rb_class_name(klass);
     }
     else
     {

--- a/ext/ruby_prof/rp_method.c
+++ b/ext/ruby_prof/rp_method.c
@@ -218,8 +218,10 @@ prof_method_create(VALUE klass, ID mid, const char* source_file, int line)
     result->source_klass = Qnil;
     result->line = line;
 
+    result->recursive = 0;
     result->resolved = 0;
     result->relation = 0;
+    result->visits = 0;
 
     return result;
 }
@@ -547,6 +549,17 @@ prof_method_call_infos(VALUE self)
 }
 
 /* call-seq:
+   recursive? -> boolean
+
+   Returns the true if this method is recursive */
+static VALUE
+prof_method_recursive(VALUE self)
+{
+  prof_method_t *method = get_prof_method(self);
+  return method->recursive ? Qtrue : Qfalse;
+}
+
+/* call-seq:
    source_klass -> klass
 
 Returns the Ruby klass of the natural source-level definition. */
@@ -581,10 +594,12 @@ void rp_init_method_info()
     rb_define_method(cMethodInfo, "method_name", prof_method_name, 0);
     rb_define_method(cMethodInfo, "full_name", prof_full_name, 0);
     rb_define_method(cMethodInfo, "method_id", prof_method_id, 0);
-    rb_define_method(cMethodInfo, "source_file", prof_method_source_file,0);
-    rb_define_method(cMethodInfo, "line", prof_method_line, 0);
-    rb_define_method(cMethodInfo, "call_infos", prof_method_call_infos, 0);
 
+    rb_define_method(cMethodInfo, "call_infos", prof_method_call_infos, 0);
     rb_define_method(cMethodInfo, "source_klass", prof_source_klass, 0);
+    rb_define_method(cMethodInfo, "source_file", prof_method_source_file, 0);
+    rb_define_method(cMethodInfo, "line", prof_method_line, 0);
+
+    rb_define_method(cMethodInfo, "recursive?", prof_method_recursive, 0);
     rb_define_method(cMethodInfo, "calltree_name", prof_calltree_name, 0);
 }

--- a/ext/ruby_prof/rp_method.c
+++ b/ext/ruby_prof/rp_method.c
@@ -228,6 +228,9 @@ prof_method_free(prof_method_t* method)
 void
 prof_method_mark(prof_method_t *method)
 {
+    if (method->key->klass)
+        rb_gc_mark(method->key->klass);
+
     if (method->resolved_klass)
         rb_gc_mark(method->resolved_klass);
 

--- a/ext/ruby_prof/rp_method.h
+++ b/ext/ruby_prof/rp_method.h
@@ -33,7 +33,11 @@ typedef struct
     /* Hot */
 
     prof_method_key_t *key;                 /* Table key */
+
     struct prof_call_infos_t *call_infos;   /* Call infos */
+    int visits;                             /* Current visits on the stack */
+
+    unsigned int recursive : 1;             /* Recursive (direct/mutual)? */
 
     /* Cold */
 

--- a/ext/ruby_prof/rp_method.h
+++ b/ext/ruby_prof/rp_method.h
@@ -26,6 +26,8 @@ typedef struct
     prof_method_key_t *key;                 /* Method key */
     const char *source_file;                /* The method's source file */
     int line;                               /* The method's line number. */
+    VALUE resolved_klass;                   /* The method's resolved class */
+    int flags;                              /* The method's resolved class relationship */
     struct prof_call_infos_t *call_infos;   /* Call info objects for this method */
     VALUE object;                           /* Cached ruby object */
 } prof_method_t;

--- a/ext/ruby_prof/rp_method.h
+++ b/ext/ruby_prof/rp_method.h
@@ -16,20 +16,34 @@ typedef struct
     st_index_t key;                         /* Cache calculated key */
 } prof_method_key_t;
 
+/* Source relation bit offsets. */
+enum {
+    kModuleIncludee = 0,                    /* Included module */
+    kModuleSingleton,                       /* Singleton class of a module */
+    kObjectSingleton                        /* Singleton class of an object */
+};
 
 /* Forward declaration, see rp_call_info.h */
 struct prof_call_infos_t;
 
 /* Profiling information for each method. */
-typedef struct 
+/* Eliminated methods have no call_infos, source_file, or source_module. */
+typedef struct
 {
-    prof_method_key_t *key;                 /* Method key */
-    const char *source_file;                /* The method's source file */
-    int line;                               /* The method's line number. */
-    VALUE resolved_klass;                   /* The method's resolved class */
-    int flags;                              /* The method's resolved class relationship */
-    struct prof_call_infos_t *call_infos;   /* Call info objects for this method */
+    /* Hot */
+
+    prof_method_key_t *key;                 /* Table key */
+    struct prof_call_infos_t *call_infos;   /* Call infos */
+
+    /* Cold */
+
     VALUE object;                           /* Cached ruby object */
+    VALUE source_klass;                     /* Source class */
+    const char *source_file;                /* Source file */
+    int line;                               /* Line number */
+
+    unsigned int resolved : 1;              /* Source resolved? */
+    unsigned int relation : 3;              /* Source relation bits */
 } prof_method_t;
 
 void rp_init_method_info(void);

--- a/ext/ruby_prof/rp_stack.h
+++ b/ext/ruby_prof/rp_stack.h
@@ -13,7 +13,7 @@
 /* Temporary object that maintains profiling information
    for active methods.  They are created and destroyed
    as the program moves up and down its stack. */
-typedef struct 
+typedef struct
 {
     /* Caching prof_method_t values significantly
        increases performance. */
@@ -44,7 +44,7 @@ typedef struct
 
 prof_stack_t * prof_stack_create();
 void prof_stack_free(prof_stack_t *stack);
-prof_frame_t * prof_stack_push(prof_stack_t *stack, double measurement);
+prof_frame_t * prof_stack_push(prof_stack_t *stack, prof_call_info_t *call_info, double measurement);
 prof_frame_t * prof_stack_pop(prof_stack_t *stack, double measurement);
 prof_frame_t * prof_stack_peek(prof_stack_t *stack);
 

--- a/ext/ruby_prof/ruby_prof.c
+++ b/ext/ruby_prof/ruby_prof.c
@@ -282,9 +282,7 @@ prof_event_hook(rb_event_flag_t event, VALUE data, VALUE self, ID mid, VALUE kla
         }
 
         /* Push a new frame onto the stack for a new c-call or ruby call (into a method) */
-        frame = prof_stack_push(thread_data->stack, measurement);
-        frame->call_info = call_info;
-		frame->call_info->depth = frame->depth;
+        frame = prof_stack_push(thread_data->stack, call_info, measurement);
         frame->pause_time = profile->paused == Qtrue ? measurement : -1;
         frame->line = rb_sourceline();
         break;
@@ -292,8 +290,8 @@ prof_event_hook(rb_event_flag_t event, VALUE data, VALUE self, ID mid, VALUE kla
     case RUBY_EVENT_RETURN:
     case RUBY_EVENT_C_RETURN:
     {
-	  prof_stack_pop(thread_data->stack, measurement);
-      break;
+        prof_stack_pop(thread_data->stack, measurement);
+        break;
     }
   }
 }
@@ -604,9 +602,6 @@ prof_stop(VALUE self)
        and the threads table */
     profile->running = profile->paused = Qfalse;
     profile->last_thread_data = NULL;
-
-    /* Post process result */
-    rb_funcall(self, rb_intern("post_process") , 0);
 
     return self;
 }

--- a/lib/ruby-prof/call_info.rb
+++ b/lib/ruby-prof/call_info.rb
@@ -9,17 +9,6 @@ module RubyProf
     # children:   array of call info children (can be empty)
     # target:     method info (containing an array of call infos)
 
-    attr_reader :recursive
-
-    def detect_recursion(visited_methods = Hash.new(0))
-      @recursive = (visited_methods[target] += 1) > 1
-      children.each do |child|
-        child.detect_recursion(visited_methods)
-      end
-      visited_methods.delete(target) if (visited_methods[target] -= 1) == 0
-      return @recursive
-    end
-
     def children_time
       children.inject(0) do |sum, call_info|
         sum += call_info.total_time

--- a/lib/ruby-prof/method_info.rb
+++ b/lib/ruby-prof/method_info.rb
@@ -18,10 +18,6 @@ module RubyProf
       end
     end
 
-    def detect_recursion
-      call_infos.each(&:detect_recursion)
-    end
-
     def called
       @called ||= begin
         call_infos.inject(0) do |sum, call_info|
@@ -33,7 +29,7 @@ module RubyProf
     def total_time
       @total_time ||= begin
         call_infos.inject(0) do |sum, call_info|
-          sum += call_info.total_time unless call_info.recursive
+          sum += call_info.total_time if !call_info.recursive?
           sum
         end
       end
@@ -42,7 +38,7 @@ module RubyProf
     def self_time
       @self_time ||= begin
         call_infos.inject(0) do |sum, call_info|
-          sum += call_info.self_time unless call_info.recursive
+          sum += call_info.self_time if !call_info.recursive?
           sum
         end
       end
@@ -51,7 +47,7 @@ module RubyProf
     def wait_time
       @wait_time ||= begin
         call_infos.inject(0) do |sum, call_info|
-          sum += call_info.wait_time unless call_info.recursive
+          sum += call_info.wait_time if !call_info.recursive?
           sum
         end
       end
@@ -60,7 +56,7 @@ module RubyProf
     def children_time
       @children_time ||= begin
         call_infos.inject(0) do |sum, call_info|
-          sum += call_info.children_time unless call_info.recursive
+          sum += call_info.children_time if !call_info.recursive?
           sum
         end
       end
@@ -76,10 +72,6 @@ module RubyProf
           not call_info.root?
         end.nil?
       end
-    end
-
-    def recursive?
-      (@recursive ||= call_infos.detect(&:recursive) ? :true : :false) == :true
     end
 
     def children

--- a/lib/ruby-prof/printers/call_info_printer.rb
+++ b/lib/ruby-prof/printers/call_info_printer.rb
@@ -31,7 +31,7 @@ module RubyProf
           @output << "wt:#{sprintf("%#{TIME_WIDTH}.2f", call_info.wait_time)}, "
           @output << "ct:#{sprintf("%#{TIME_WIDTH}.2f", call_info.children_time)}, "
           @output << "call:#{call_info.called}, "
-          @output << "rec:#{call_info.recursive}"
+          @output << "rec:#{call_info.recursive?}"
           @output << ")"
           @output << "\n"
         end

--- a/lib/ruby-prof/printers/call_tree_printer.rb
+++ b/lib/ruby-prof/printers/call_tree_printer.rb
@@ -110,7 +110,7 @@ module RubyProf
     def print_method(output, method)
       # Print out the file and method name
       output << "fl=#{file(method)}\n"
-      output << "fn=#{method_name(method)}\n"
+      output << "fn=#{method.calltree_name}\n"
 
       # Now print out the function line number and its self time
       output << "#{method.line} #{convert(method.self_time)}\n"
@@ -118,7 +118,7 @@ module RubyProf
       # Now print out all the children methods
       method.children.each do |callee|
         output << "cfl=#{file(callee.target)}\n"
-        output << "cfn=#{method_name(callee.target)}\n"
+        output << "cfn=#{callee.target.calltree_name}\n"
         output << "calls=#{callee.called} #{callee.line}\n"
 
         # Print out total times here!

--- a/lib/ruby-prof/profile.rb
+++ b/lib/ruby-prof/profile.rb
@@ -2,15 +2,6 @@
 
 module RubyProf
   class Profile
-    # This method gets called once profiling has been completed
-    # but before results are returned to the user.  Thus it provides
-    # a hook to do any necessary post-processing on the call graph.
-    def post_process
-      self.threads.each do |thread|
-        thread.detect_recursion
-      end
-    end
-
     # eliminate some calls from the graph by merging the information into callers.
     # matchers can be a list of strings or regular expressions or the name of a file containing regexps.
     def eliminate_methods!(matchers)

--- a/lib/ruby-prof/thread.rb
+++ b/lib/ruby-prof/thread.rb
@@ -10,12 +10,6 @@ module RubyProf
       top_methods.map(&:call_infos).flatten.select(&:root?)
     end
 
-    # This method detect recursive calls in the call tree of a given thread
-    # It should be called only once for each thread
-    def detect_recursion
-      top_call_infos.each(&:detect_recursion)
-    end
-
     def total_time
       self.top_methods.inject(0) do |sum, method_info|
         method_info.call_infos.each do |call_info|

--- a/test/aggregate_test.rb
+++ b/test/aggregate_test.rb
@@ -44,7 +44,7 @@ class AggregateTest < TestCase
     methods = result.threads.first.methods.sort.reverse
     methods.each do |m|
       m.call_infos.each do |ci|
-        assert(!ci.recursive)
+        assert(!ci.recursive?)
       end
     end
   end

--- a/test/no_method_class_test.rb
+++ b/test/no_method_class_test.rb
@@ -10,6 +10,6 @@ end
 
 methods = result.threads.first.methods
 global_method = methods.sort_by {|method| method.full_name}.first
-if global_method.full_name != 'Global#[No method]'
+if global_method.full_name != 'Kernel#sleep'
   raise(RuntimeError, "Wrong method name.  Expected: Global#[No method].  Actual: #{global_method.full_name}")
 end

--- a/test/printers_test.rb
+++ b/test/printers_test.rb
@@ -120,7 +120,7 @@ class PrintersTest < TestCase
     main_output_file_name = File.join(RubyProf.tmpdir, "lolcat.callgrind.out.#{$$}")
     assert(File.exist?(main_output_file_name))
     output = File.read(main_output_file_name)
-    assert_match(/fn=Object#find_primes/i, output)
+    assert_match(/fn=Object::find_primes/i, output)
     assert_match(/events: wall_time/i, output)
     refute_match(/d\d\d\d\d\d/, output) # old bug looked [in error] like Object::run_primes(d5833116)
   end

--- a/test/recursive_test.rb
+++ b/test/recursive_test.rb
@@ -64,7 +64,7 @@ class RecursiveTest < TestCase
 
     assert_equal(1, method.call_infos.length)
     call_info = method.call_infos[0]
-    assert(!call_info.recursive)
+    assert(!call_info.recursive?)
     assert_equal('RecursiveTest#test_simple', call_info.call_sequence)
     assert_equal(1, call_info.children.length)
 
@@ -82,12 +82,12 @@ class RecursiveTest < TestCase
     call_info = method.call_infos.first
     assert_equal(2, call_info.children.length)
     assert_equal('RecursiveTest#test_simple->SimpleRecursion#simple', call_info.call_sequence)
-    assert(!call_info.recursive)
+    assert(!call_info.recursive?)
 
     call_info = method.call_infos.last
     assert_equal(1, call_info.children.length)
     assert_equal('RecursiveTest#test_simple->SimpleRecursion#simple->SimpleRecursion#simple', call_info.call_sequence)
-    assert(call_info.recursive)
+    assert(call_info.recursive?)
 
     method = methods[2]
     assert_equal('Kernel#sleep', method.full_name)
@@ -101,12 +101,12 @@ class RecursiveTest < TestCase
     call_info = method.call_infos[0]
     assert_equal('RecursiveTest#test_simple->SimpleRecursion#simple->Kernel#sleep', call_info.call_sequence)
     assert_equal(0, call_info.children.length)
-    assert(!call_info.recursive)
+    assert(!call_info.recursive?)
 
     call_info = method.call_infos[1]
     assert_equal('RecursiveTest#test_simple->SimpleRecursion#simple->SimpleRecursion#simple->Kernel#sleep', call_info.call_sequence)
     assert_equal(0, call_info.children.length)
-    assert(!call_info.recursive)
+    assert(!call_info.recursive?)
   end
 
   def test_cycle
@@ -129,7 +129,7 @@ class RecursiveTest < TestCase
     call_info = method.call_infos[0]
     assert_equal('RecursiveTest#test_cycle', call_info.call_sequence)
     assert_equal(1, call_info.children.length)
-    assert(!call_info.recursive)
+    assert(!call_info.recursive?)
 
     method = methods[1]
     assert_equal('SimpleRecursion#render', method.full_name)
@@ -143,7 +143,7 @@ class RecursiveTest < TestCase
     call_info = method.call_infos[0]
     assert_equal('RecursiveTest#test_cycle->SimpleRecursion#render', call_info.call_sequence)
     assert_equal(1, call_info.children.length)
-    assert(!call_info.recursive)
+    assert(!call_info.recursive?)
 
     method = methods[2]
     assert_equal('Integer#times', method.full_name)
@@ -157,12 +157,12 @@ class RecursiveTest < TestCase
     call_info = method.call_infos[0]
     assert_equal('RecursiveTest#test_cycle->SimpleRecursion#render->Integer#times', call_info.call_sequence)
     assert_equal(1, call_info.children.length)
-    assert(!call_info.recursive)
+    assert(!call_info.recursive?)
 
     call_info = method.call_infos[1]
     assert_equal('RecursiveTest#test_cycle->SimpleRecursion#render->Integer#times->SimpleRecursion#render_partial->Integer#times', call_info.call_sequence)
     assert_equal(1, call_info.children.length)
-    assert(call_info.recursive)
+    assert(call_info.recursive?)
 
     method = methods[3]
     assert_equal('SimpleRecursion#render_partial', method.full_name)
@@ -176,17 +176,17 @@ class RecursiveTest < TestCase
     call_info = method.call_infos[0]
     assert_equal('RecursiveTest#test_cycle->SimpleRecursion#render->Integer#times->SimpleRecursion#render_partial', call_info.call_sequence)
     assert_equal(3, call_info.children.length)
-    assert(!call_info.recursive)
+    assert(!call_info.recursive?)
 
     call_info = method.call_infos[1]
     assert_equal('RecursiveTest#test_cycle->SimpleRecursion#render->Integer#times->SimpleRecursion#render_partial->SimpleRecursion#render_partial', call_info.call_sequence)
     assert_equal(1, call_info.children.length)
-    assert(call_info.recursive)
+    assert(call_info.recursive?)
 
     call_info = method.call_infos[2]
     assert_equal('RecursiveTest#test_cycle->SimpleRecursion#render->Integer#times->SimpleRecursion#render_partial->Integer#times->SimpleRecursion#render_partial', call_info.call_sequence)
     assert_equal(1, call_info.children.length)
-    assert(call_info.recursive)
+    assert(call_info.recursive?)
 
     method = methods[4]
     assert_equal('Kernel#sleep', method.full_name)
@@ -200,16 +200,16 @@ class RecursiveTest < TestCase
     call_info = method.call_infos[0]
     assert_equal('RecursiveTest#test_cycle->SimpleRecursion#render->Integer#times->SimpleRecursion#render_partial->Kernel#sleep', call_info.call_sequence)
     assert_equal(0, call_info.children.length)
-    assert(!call_info.recursive)
+    assert(!call_info.recursive?)
 
     call_info = method.call_infos[1]
     assert_equal('RecursiveTest#test_cycle->SimpleRecursion#render->Integer#times->SimpleRecursion#render_partial->SimpleRecursion#render_partial->Kernel#sleep', call_info.call_sequence)
     assert_equal(0, call_info.children.length)
-    assert(!call_info.recursive)
+    assert(!call_info.recursive?)
 
     call_info = method.call_infos[2]
     assert_equal('RecursiveTest#test_cycle->SimpleRecursion#render->Integer#times->SimpleRecursion#render_partial->Integer#times->SimpleRecursion#render_partial->Kernel#sleep', call_info.call_sequence)
     assert_equal(0, call_info.children.length)
-    assert(!call_info.recursive)
+    assert(!call_info.recursive?)
   end
 end


### PR DESCRIPTION
Refer to https://github.com/ruby-prof/ruby-prof/pull/200 for more context.

We encountered SystemStackErrors during the post processing phase when
using the recursive ruby definition of recursion detection.  The post
processing phase is also rather time consuming because it requires
turning the `prof_call_info_t` structs into full Ruby objects.

This commit addresses both issues by performing the logic of
`CallInfo#detect_recursion` but from the stack operations during
profiling.

/cc @skaes @nelgau
