### PR TITLE
Extract method elimination (as exclusion) into the C extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ examples2
 .rvmrc
 Gemfile.lock
 /profile.callgrind.out.*
+*.gem
+.ruby-version

--- a/ext/ruby_prof/extconf.rb
+++ b/ext/ruby_prof/extconf.rb
@@ -10,6 +10,9 @@ if RUBY_VERSION < "1.9.3"
   exit(1)
 end
 
+# For the love of bitfields...
+$CFLAGS += ' -std=c99'
+
 # standard ruby methods
 have_func("rb_gc_stat")
 have_func("rb_gc_count")

--- a/ext/ruby_prof/rp_method.c
+++ b/ext/ruby_prof/rp_method.c
@@ -29,7 +29,7 @@ figure_singleton_name(VALUE klass)
     if (BUILTIN_TYPE(attached) == T_CLASS)
     {
         result = rb_str_new2("<Class::");
-        rb_str_append(result, rb_inspect(attached));
+        rb_str_append(result, rb_class_name(attached));
         rb_str_cat2(result, ">");
     }
 
@@ -37,7 +37,7 @@ figure_singleton_name(VALUE klass)
     else if (BUILTIN_TYPE(attached) == T_MODULE)
     {
         result = rb_str_new2("<Module::");
-        rb_str_append(result, rb_inspect(attached));
+        rb_str_append(result, rb_class_name(attached));
         rb_str_cat2(result, ">");
     }
 
@@ -49,7 +49,7 @@ figure_singleton_name(VALUE klass)
            unknown method errors. */
         VALUE super = rb_class_superclass(klass);
         result = rb_str_new2("<Object::");
-        rb_str_append(result, rb_inspect(super));
+        rb_str_append(result, rb_class_name(super));
         rb_str_cat2(result, ">");
     }
 
@@ -58,7 +58,7 @@ figure_singleton_name(VALUE klass)
        objects test case). */
     else
     {
-        result = rb_inspect(klass);
+        result = rb_any_to_s(klass);
     }
 
     return result;
@@ -75,7 +75,7 @@ klass_name(VALUE klass)
     }
     else if (BUILTIN_TYPE(klass) == T_MODULE)
     {
-        result = rb_inspect(klass);
+        result = rb_class_name(klass);
     }
     else if (BUILTIN_TYPE(klass) == T_CLASS && FL_TEST(klass, FL_SINGLETON))
     {
@@ -83,7 +83,7 @@ klass_name(VALUE klass)
     }
     else if (BUILTIN_TYPE(klass) == T_CLASS)
     {
-        result = rb_inspect(klass);
+        result = rb_class_name(klass);
     }
     else
     {

--- a/ext/ruby_prof/rp_method.c
+++ b/ext/ruby_prof/rp_method.c
@@ -228,6 +228,9 @@ prof_method_free(prof_method_t* method)
 void
 prof_method_mark(prof_method_t *method)
 {
+    if (method->key->klass)
+        rb_gc_mark(method->key->klass);
+
     if (method->resolved_klass)
         rb_gc_mark(method->resolved_klass);
 

--- a/ext/ruby_prof/rp_method.h
+++ b/ext/ruby_prof/rp_method.h
@@ -26,6 +26,8 @@ typedef struct
     prof_method_key_t *key;                 /* Method key */
     const char *source_file;                /* The method's source file */
     int line;                               /* The method's line number. */
+    VALUE resolved_klass;                   /* The method's resolved class */
+    int flags;                              /* The method's resolved class relationship */
     struct prof_call_infos_t *call_infos;   /* Call info objects for this method */
     VALUE object;                           /* Cached ruby object */
 } prof_method_t;

--- a/ext/ruby_prof/rp_method.h
+++ b/ext/ruby_prof/rp_method.h
@@ -27,13 +27,15 @@ enum {
 struct prof_call_infos_t;
 
 /* Profiling information for each method. */
-/* Eliminated methods have no call_infos, source_file, or source_module. */
+/* Excluded methods have no call_infos, source_klass, or source_file. */
 typedef struct
 {
     /* Hot */
 
     prof_method_key_t *key;                 /* Table key */
     struct prof_call_infos_t *call_infos;   /* Call infos */
+
+    unsigned int excluded : 1;              /* Exclude from profile? */
 
     /* Cold */
 
@@ -56,6 +58,8 @@ size_t method_table_insert(st_table *table, const prof_method_key_t *key, prof_m
 void method_table_free(st_table *table);
 
 prof_method_t* prof_method_create(VALUE klass, ID mid, const char* source_file, int line);
+prof_method_t* prof_method_create_excluded(VALUE klass, ID mid);
+
 VALUE prof_method_wrap(prof_method_t *result);
 void prof_method_mark(prof_method_t *method);
 

--- a/ext/ruby_prof/rp_method.h
+++ b/ext/ruby_prof/rp_method.h
@@ -16,20 +16,34 @@ typedef struct
     st_index_t key;                         /* Cache calculated key */
 } prof_method_key_t;
 
+/* Source relation bit offsets. */
+enum {
+    kModuleIncludee = 0,                    /* Included module */
+    kModuleSingleton,                       /* Singleton class of a module */
+    kObjectSingleton                        /* Singleton class of an object */
+};
 
 /* Forward declaration, see rp_call_info.h */
 struct prof_call_infos_t;
 
 /* Profiling information for each method. */
-typedef struct 
+/* Eliminated methods have no call_infos, source_file, or source_module. */
+typedef struct
 {
-    prof_method_key_t *key;                 /* Method key */
-    const char *source_file;                /* The method's source file */
-    int line;                               /* The method's line number. */
-    VALUE resolved_klass;                   /* The method's resolved class */
-    int flags;                              /* The method's resolved class relationship */
-    struct prof_call_infos_t *call_infos;   /* Call info objects for this method */
+    /* Hot */
+
+    prof_method_key_t *key;                 /* Table key */
+    struct prof_call_infos_t *call_infos;   /* Call infos */
+
+    /* Cold */
+
     VALUE object;                           /* Cached ruby object */
+    VALUE source_klass;                     /* Source class */
+    const char *source_file;                /* Source file */
+    int line;                               /* Line number */
+
+    unsigned int resolved : 1;              /* Source resolved? */
+    unsigned int relation : 3;              /* Source relation bits */
 } prof_method_t;
 
 void rp_init_method_info(void);

--- a/ext/ruby_prof/rp_thread.c
+++ b/ext/ruby_prof/rp_thread.c
@@ -217,7 +217,10 @@ collect_methods(st_data_t key, st_data_t value, st_data_t result)
        We want to store the method info information into an array.*/
     VALUE methods = (VALUE) result;
     prof_method_t *method = (prof_method_t *) value;
-    rb_ary_push(methods, prof_method_wrap(method));
+
+    if (!method->excluded) {
+      rb_ary_push(methods, prof_method_wrap(method));
+    }
 
     return ST_CONTINUE;
 }

--- a/ext/ruby_prof/ruby_prof.h
+++ b/ext/ruby_prof/ruby_prof.h
@@ -42,11 +42,14 @@ typedef struct
 {
     VALUE running;
     VALUE paused;
+
     prof_measurer_t* measurer;
     VALUE threads;
+
     st_table* threads_tbl;
     st_table* exclude_threads_tbl;
     st_table* include_threads_tbl;
+    st_table* exclude_methods_tbl;
     thread_data_t* last_thread_data;
     double measurement_at_pause_resume;
     int merge_fibers;

--- a/lib/ruby-prof/printers/call_tree_printer.rb
+++ b/lib/ruby-prof/printers/call_tree_printer.rb
@@ -110,7 +110,7 @@ module RubyProf
     def print_method(output, method)
       # Print out the file and method name
       output << "fl=#{file(method)}\n"
-      output << "fn=#{method_name(method)}\n"
+      output << "fn=#{method.calltree_name}\n"
 
       # Now print out the function line number and its self time
       output << "#{method.line} #{convert(method.self_time)}\n"
@@ -118,7 +118,7 @@ module RubyProf
       # Now print out all the children methods
       method.children.each do |callee|
         output << "cfl=#{file(callee.target)}\n"
-        output << "cfn=#{method_name(callee.target)}\n"
+        output << "cfn=#{callee.target.calltree_name}\n"
         output << "calls=#{callee.called} #{callee.line}\n"
 
         # Print out total times here!

--- a/lib/ruby-prof/profile.rb
+++ b/lib/ruby-prof/profile.rb
@@ -1,5 +1,8 @@
 # encoding: utf-8
 
+require 'ruby-prof/profile/exclude_common_methods'
+require 'ruby-prof/profile/legacy_method_elimination'
+
 module RubyProf
   class Profile
     # This method gets called once profiling has been completed
@@ -11,45 +14,22 @@ module RubyProf
       end
     end
 
-    # eliminate some calls from the graph by merging the information into callers.
-    # matchers can be a list of strings or regular expressions or the name of a file containing regexps.
-    def eliminate_methods!(matchers)
-      matchers = read_regexps_from_file(matchers) if matchers.is_a?(String)
-      eliminated = []
-      threads.each do |thread|
-        matchers.each{ |matcher| eliminated.concat(eliminate_methods(thread.methods, matcher)) }
-      end
-      eliminated
+    include LegacyMethodElimination
+
+    # Hides methods that, when represented as a call graph, have
+    # extremely large in and out degrees and make navigation impossible.
+    def exclude_common_methods!
+      ExcludeCommonMethods.apply!(self)
     end
 
-    private
-
-    # read regexps from file
-    def read_regexps_from_file(file_name)
-      matchers = []
-      File.open(file_name).each_line do |l|
-        next if (l =~ /^(#.*|\s*)$/) # emtpy lines and lines starting with #
-        matchers << Regexp.new(l.strip)
+    def exclude_methods!(mod, *method_or_methods)
+      [method_or_methods].flatten.each do |name|
+        exclude_method!(mod, name)
       end
     end
 
-    # eliminate methods matching matcher
-    def eliminate_methods(methods, matcher)
-      eliminated = []
-      i = 0
-      while i < methods.size
-        method_info = methods[i]
-        method_name = method_info.full_name
-        if matcher === method_name
-          raise "can't eliminate root method" if method_info.root?
-          eliminated << methods.delete_at(i)
-          method_info.eliminate!
-        else
-          i += 1
-        end
-      end
-      eliminated
+    def exclude_singleton_methods!(mod, *method_or_methods)
+      exclude_methods!(mod.singleton_class, *method_or_methods)
     end
-
   end
 end

--- a/lib/ruby-prof/profile/exclude_common_methods.rb
+++ b/lib/ruby-prof/profile/exclude_common_methods.rb
@@ -1,0 +1,191 @@
+require 'set'
+
+module RubyProf
+  class Profile
+    class ExcludeCommonMethods
+      ENUMERABLE_NAMES = Enumerable.instance_methods(false)
+
+      def self.apply!(profile)
+        new(profile).apply!
+      end
+
+      def initialize(profile)
+        @profile = profile
+      end
+
+      def apply!
+        ##
+        #  Kernel Methods
+        ##
+
+        exclude_methods Kernel, [
+          :dup,
+          :initialize_dup,
+          :tap,
+          :send,
+          :public_send,
+        ]
+
+        ##
+        #  Fundamental Types
+        ##
+
+        exclude_methods BasicObject,  :"!="
+        exclude_methods Method,       :"[]"
+        exclude_methods Module,       :new
+        exclude_methods Class,        :new
+        exclude_methods Proc,         :call, :yield
+        exclude_methods Range,        :each
+        exclude_methods Integer,      :times
+
+        ##
+        #  Value Types
+        ##
+
+        exclude_methods String, [
+          :sub,
+          :sub!,
+          :gsub,
+          :gsub!,
+        ]
+
+        ##
+        #  Emumerables
+        ##
+
+        exclude_enumerable Enumerable
+        exclude_enumerable Enumerator
+
+        ##
+        #  Collections
+        ##
+
+        exclude_enumerable Array, [
+          :each_index,
+          :map!,
+          :select!,
+          :reject!,
+          :collect!,
+          :sort!,
+          :sort_by!,
+          :index,
+          :delete_if,
+          :keep_if,
+          :drop_while,
+          :uniq,
+          :uniq!,
+          :"==",
+          :eql?,
+          :hash,
+          :to_json,
+          :as_json,
+          :encode_json,
+        ]
+
+        exclude_enumerable Hash, [
+          :dup,
+          :initialize_dup,
+          :fetch,
+          :"[]",
+          :"[]=",
+          :each_key,
+          :each_value,
+          :each_pair,
+          :map!,
+          :select!,
+          :reject!,
+          :collect!,
+          :delete_if,
+          :keep_if,
+          :slice,
+          :slice!,
+          :except,
+          :except!,
+          :"==",
+          :eql?,
+          :hash,
+          :to_json,
+          :as_json,
+          :encode_json,
+        ]
+
+        exclude_enumerable Set, [
+          :map!,
+          :select!,
+          :reject!,
+          :collect!,
+          :classify,
+          :delete_if,
+          :keep_if,
+          :divide,
+          :"==",
+          :eql?,
+          :hash,
+          :to_json,
+          :as_json,
+          :encode_json,
+        ]
+
+        ##
+        #  Garbage Collection
+        ##
+
+        exclude_singleton_methods GC, [
+          :start
+        ]
+
+        ##
+        #  Unicorn
+        ##
+
+        if defined?(Unicorn)
+          exclude_methods Unicorn::HttpServer, :process_client
+        end
+
+        if defined?(Unicorn::OobGC)
+          exclude_methods Unicorn::OobGC, :process_client
+        end
+
+        ##
+        #  New Relic
+        ##
+
+        if defined?(NewRelic)
+          exclude_methods NewRelic::Agent::Instrumentation::MiddlewareTracing, [
+            :call
+          ]
+
+          exclude_methods NewRelic::Agent::MethodTracerHelpers, [
+            :trace_execution_scoped,
+            :log_errors,
+          ]
+
+          exclude_singleton_methods NewRelic::Agent::MethodTracerHelpers, [
+            :trace_execution_scoped,
+            :log_errors,
+          ]
+
+          exclude_methods NewRelic::Agent::MethodTracer, [
+            :trace_execution_scoped,
+            :trace_execution_unscoped,
+          ]
+        end
+      end
+
+      private
+
+      def exclude_methods(mod, *method_or_methods)
+        @profile.exclude_methods!(mod, method_or_methods)
+      end
+
+      def exclude_singleton_methods(mod, *method_or_methods)
+        @profile.exclude_singleton_methods!(mod, method_or_methods)
+      end
+
+      def exclude_enumerable(mod, *method_or_methods)
+        exclude_methods(mod, [:each, *method_or_methods])
+        exclude_methods(mod, ENUMERABLE_NAMES)
+      end
+    end
+  end
+end

--- a/lib/ruby-prof/profile/legacy_method_elimination.rb
+++ b/lib/ruby-prof/profile/legacy_method_elimination.rb
@@ -1,0 +1,45 @@
+module RubyProf
+  class Profile
+    module LegacyMethodElimination
+      # eliminate some calls from the graph by merging the information into callers.
+      # matchers can be a list of strings or regular expressions or the name of a file containing regexps.
+      def eliminate_methods!(matchers)
+        matchers = read_regexps_from_file(matchers) if matchers.is_a?(String)
+        eliminated = []
+        threads.each do |thread|
+          matchers.each{ |matcher| eliminated.concat(eliminate_methods(thread.methods, matcher)) }
+        end
+        eliminated
+      end
+
+      private
+
+      # read regexps from file
+      def read_regexps_from_file(file_name)
+        matchers = []
+        File.open(file_name).each_line do |l|
+          next if (l =~ /^(#.*|\s*)$/) # emtpy lines and lines starting with #
+          matchers << Regexp.new(l.strip)
+        end
+      end
+
+      # eliminate methods matching matcher
+      def eliminate_methods(methods, matcher)
+        eliminated = []
+        i = 0
+        while i < methods.size
+          method_info = methods[i]
+          method_name = method_info.full_name
+          if matcher === method_name
+            raise "can't eliminate root method" if method_info.root?
+            eliminated << methods.delete_at(i)
+            method_info.eliminate!
+          else
+            i += 1
+          end
+        end
+        eliminated
+      end
+    end
+  end
+end

--- a/ruby-prof.gemspec
+++ b/ruby-prof.gemspec
@@ -44,6 +44,7 @@ EOF
                    'lib/unprof.rb',
                    'lib/ruby-prof/*.rb',
                    'lib/ruby-prof/assets/*.{html,png}',
+                   'lib/ruby-prof/profile/*.rb',
                    'lib/ruby-prof/printers/*.rb',
                    'test/*.rb']
 

--- a/test/exclude_methods_test.rb
+++ b/test/exclude_methods_test.rb
@@ -1,0 +1,146 @@
+#!/usr/bin/env ruby
+# encoding: UTF-8
+
+require File.expand_path('../test_helper', __FILE__)
+
+module ExcludeMethodsModule
+  def c
+    1.times { |i| ExcludeMethodsModule.d }
+  end
+
+  def self.d
+    1.times { |i| ExcludeMethodsClass.e }
+  end
+end
+
+class ExcludeMethodsClass
+  include ExcludeMethodsModule
+
+  def a
+    1.times { |i| b }
+  end
+
+  def b
+    1.times { |i| c; self.class.e }
+  end
+
+  def self.e
+    1.times { |i| f }
+  end
+
+  def self.f
+    sleep 0.1
+  end
+end
+
+class ExcludeMethodsTest < TestCase
+  def setup
+    # Need to use wall time for this test due to the sleep calls
+    RubyProf::measure_mode = RubyProf::WALL_TIME
+  end
+
+  def test_methods_can_be_profiled
+    obj = ExcludeMethodsClass.new
+    prf = RubyProf::Profile.new
+
+    result = prf.profile { 5.times {obj.a} }
+    methods = result.threads.first.methods.sort.reverse
+
+    assert_equal(10, methods.count)
+    assert_equal('ExcludeMethodsTest#test_methods_can_be_profiled', methods[0].full_name)
+    assert_equal('Integer#times', methods[1].full_name)
+    assert_equal('ExcludeMethodsClass#a', methods[2].full_name)
+    assert_equal('ExcludeMethodsClass#b', methods[3].full_name)
+    assert_equal('<Class::ExcludeMethodsClass>#e', methods[4].full_name)
+    assert_equal('<Class::ExcludeMethodsClass>#f', methods[5].full_name)
+    assert_equal('Kernel#sleep', methods[6].full_name)
+    assert_equal('ExcludeMethodsModule#c', methods[7].full_name)
+    assert_equal('<Module::ExcludeMethodsModule>#d', methods[8].full_name)
+    assert_equal('Kernel#class', methods[9].full_name)
+  end
+
+  def test_methods_can_be_hidden1
+    obj = ExcludeMethodsClass.new
+    prf = RubyProf::Profile.new
+
+    prf.exclude_methods!(Integer, :times)
+
+    result = prf.profile { 5.times {obj.a} }
+    methods = result.threads.first.methods.sort.reverse
+
+    assert_equal(9, methods.count)
+    assert_equal('ExcludeMethodsTest#test_methods_can_be_hidden1', methods[0].full_name)
+    assert_equal('ExcludeMethodsClass#a', methods[1].full_name)
+    assert_equal('ExcludeMethodsClass#b', methods[2].full_name)
+    assert_equal('<Class::ExcludeMethodsClass>#e', methods[3].full_name)
+    assert_equal('<Class::ExcludeMethodsClass>#f', methods[4].full_name)
+    assert_equal('Kernel#sleep', methods[5].full_name)
+    assert_equal('ExcludeMethodsModule#c', methods[6].full_name)
+    assert_equal('<Module::ExcludeMethodsModule>#d', methods[7].full_name)
+    assert_equal('Kernel#class', methods[8].full_name)
+  end
+
+  def test_methods_can_be_hidden2
+    obj = ExcludeMethodsClass.new
+    prf = RubyProf::Profile.new
+
+    prf.exclude_methods!(Integer, :times)
+    prf.exclude_methods!(ExcludeMethodsClass.singleton_class, :f)
+    prf.exclude_methods!(ExcludeMethodsModule.singleton_class, :d)
+
+    result = prf.profile { 5.times {obj.a} }
+    methods = result.threads.first.methods.sort.reverse
+
+    assert_equal(7, methods.count)
+    assert_equal('ExcludeMethodsTest#test_methods_can_be_hidden2', methods[0].full_name)
+    assert_equal('ExcludeMethodsClass#a', methods[1].full_name)
+    assert_equal('ExcludeMethodsClass#b', methods[2].full_name)
+    assert_equal('<Class::ExcludeMethodsClass>#e', methods[3].full_name)
+    assert_equal('Kernel#sleep', methods[4].full_name)
+    assert_equal('ExcludeMethodsModule#c', methods[5].full_name)
+    assert_equal('Kernel#class', methods[6].full_name)
+  end
+
+  def test_exclude_common_methods1
+    obj = ExcludeMethodsClass.new
+    prf = RubyProf::Profile.new
+
+    prf.exclude_common_methods!
+
+    result = prf.profile { 5.times {obj.a} }
+    methods = result.threads.first.methods.sort.reverse
+
+    assert_equal(9, methods.count)
+    assert_equal('ExcludeMethodsTest#test_exclude_common_methods1', methods[0].full_name)
+    assert_equal('ExcludeMethodsClass#a', methods[1].full_name)
+    assert_equal('ExcludeMethodsClass#b', methods[2].full_name)
+  end
+
+  def test_exclude_common_methods2
+    obj = ExcludeMethodsClass.new
+
+    result = RubyProf.profile(exclude_common: true) { 5.times {obj.a} }
+    methods = result.threads.first.methods.sort.reverse
+
+    assert_equal(9, methods.count)
+    assert_equal('ExcludeMethodsTest#test_exclude_common_methods2', methods[0].full_name)
+    assert_equal('ExcludeMethodsClass#a', methods[1].full_name)
+    assert_equal('ExcludeMethodsClass#b', methods[2].full_name)
+  end
+
+  private
+
+  def assert_method_has_been_eliminated(result, eliminated_method)
+    result.threads.each do |thread|
+      thread.methods.each do |method|
+        method.call_infos.each do |ci|
+          assert(ci.target != eliminated_method, "broken self")
+          assert(ci.parent.target != eliminated_method, "broken parent") if ci.parent
+          ci.children.each do |callee|
+            assert(callee.target != eliminated_method, "broken kid")
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/no_method_class_test.rb
+++ b/test/no_method_class_test.rb
@@ -10,6 +10,6 @@ end
 
 methods = result.threads.first.methods
 global_method = methods.sort_by {|method| method.full_name}.first
-if global_method.full_name != 'Global#[No method]'
+if global_method.full_name != 'Kernel#sleep'
   raise(RuntimeError, "Wrong method name.  Expected: Global#[No method].  Actual: #{global_method.full_name}")
 end

--- a/test/printers_test.rb
+++ b/test/printers_test.rb
@@ -120,7 +120,7 @@ class PrintersTest < TestCase
     main_output_file_name = File.join(RubyProf.tmpdir, "lolcat.callgrind.out.#{$$}")
     assert(File.exist?(main_output_file_name))
     output = File.read(main_output_file_name)
-    assert_match(/fn=Object#find_primes/i, output)
+    assert_match(/fn=Object::find_primes/i, output)
     assert_match(/events: wall_time/i, output)
     refute_match(/d\d\d\d\d\d/, output) # old bug looked [in error] like Object::run_primes(d5833116)
   end


### PR DESCRIPTION
Refer to https://github.com/ruby-prof/ruby-prof/pull/200 for more context.

For our workload, the vast majority of the execution time of our
profiles was spent eliminating methods.  This commit almost completely
eliminates the cost of method elimination by allowing methods to be
excluded during profiling.  This prevents the `prof_method_t` structs
being turned into full Ruby objects.

This commit also moves pause state into `rp_stack`.

/cc @skaes @nelgau
