### PR TITLE
Clarify how to view executable documentation

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -48,7 +48,7 @@ line, via its convenience API or via its core API.
 
 The first is to use ruby-prof to run the Ruby program you want to
 profile.  For more information refer to the documentation of the
-ruby-prof command.
+ruby-prof command: `$ ruby-prof -h.`
 
 
 === ruby-prof Convenience API


### PR DESCRIPTION
Is there more documentation than this? I looked for documentation on the executable in generated docs / readme / github wiki before trying the executable itself.