### PR TITLE
correctly escape % in sprintf

### DIFF
--- a/lib/ruby-prof/printers/graph_html_printer.rb
+++ b/lib/ruby-prof/printers/graph_html_printer.rb
@@ -200,8 +200,8 @@ module RubyProf
                  </tr>
                <% end %>
                <tr class="method">
-                 <td><%= sprintf("%.2f\%", total_percentage) %></td>
-                 <td><%= sprintf("%.2f\%", self_percentage) %></td>
+                 <td><%= sprintf("%.2f%%", total_percentage) %></td>
+                 <td><%= sprintf("%.2f%%", self_percentage) %></td>
                  <td><%= sprintf("%.2f", method.total_time) %></td>
                  <td><%= sprintf("%.2f", method.self_time) %></td>
                  <td><%= sprintf("%.2f", method.wait_time) %></td>

--- a/lib/ruby-prof/printers/graph_printer.rb
+++ b/lib/ruby-prof/printers/graph_printer.rb
@@ -56,8 +56,8 @@ module RubyProf
         print_parents(thread, method)
 
         # 1 is for % sign
-        @output << sprintf("%#{PERCENTAGE_WIDTH-1}.2f\%", total_percentage)
-        @output << sprintf("%#{PERCENTAGE_WIDTH-1}.2f\%", self_percentage)
+        @output << sprintf("%#{PERCENTAGE_WIDTH-1}.2f%%", total_percentage)
+        @output << sprintf("%#{PERCENTAGE_WIDTH-1}.2f%%", self_percentage)
         @output << sprintf("%#{TIME_WIDTH}.3f", method.total_time)
         @output << sprintf("%#{TIME_WIDTH}.3f", method.self_time)
         @output << sprintf("%#{TIME_WIDTH}.3f", method.wait_time)


### PR DESCRIPTION
Ruby 2.5 is pickier about sprintf formatting and will raise the error linked below without this change to how sprintf is called.

https://github.com/ruby/ruby/commit/d9d2bbe4b92120003cc026176a3841c875378e7c#diff-050ece9ea0cea6d9c95cafd7ffe8de43R524