### PR TITLE
update to latest rubies on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.10
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
+  - 2.2.8
+  - 2.3.5
+  - 2.4.2
 script: "bundle exec rake clean compile test"
 sudo: false
 


### PR DESCRIPTION
This bumps the version numbers in the travis config to the latest.

Would there be merit in also adding ruby-head but allowing it to fail so we can track progress toward compatibility?