### PR TITLE
Ensure README provides executable code.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -187,7 +187,7 @@ collected metrics are identical to eliminating methods from the
 profiling result in a prost process step. The interface is slightly
 different though:
 
-    profile = RubyProf.new(...)
+    profile = RubyProf::Profile.new(...)
     profile.exclude_methods!(Integer, :times, ...)
     profile.start
 


### PR DESCRIPTION
**NB**: I am not entirely positive this is right, but it is the path
that got me to code that can execute. If I am mistaken in my approach, please
let me know.

RubyProf is a module and, thus, does not provide a method for
constructing class instances. RubyProf::Profile is the the class that
provides an interface into the core profiling API.