### PR TITLE
Add "allow_exceptions" option to Profile

### DIFF
--- a/ext/ruby_prof/ruby_prof.h
+++ b/ext/ruby_prof/ruby_prof.h
@@ -53,6 +53,7 @@ typedef struct
     thread_data_t* last_thread_data;
     double measurement_at_pause_resume;
     int merge_fibers;
+    int allow_exceptions;
 } prof_profile_t;
 
 

--- a/lib/ruby-prof/compatibility.rb
+++ b/lib/ruby-prof/compatibility.rb
@@ -145,6 +145,7 @@ module RubyProf
     gc_stat_was_enabled = enable_gc_stats_if_needed
     options = { measure_mode: measure_mode, exclude_threads: exclude_threads }.merge!(options)
     result = Profile.profile(options, &block)
+  ensure
     disable_gc_stats_if_needed(gc_stat_was_enabled)
     result
   end

--- a/test/exceptions_test.rb
+++ b/test/exceptions_test.rb
@@ -11,6 +11,14 @@ class ExceptionsTest < TestCase
       end
     rescue
     end
-    refute_nil(result)
+    assert_kind_of(RubyProf::Profile, result)
+  end
+
+  def test_profile_allows_exceptions
+    assert_raises(RuntimeError) do
+      RubyProf.profile(:allow_exceptions => true) do
+        raise(RuntimeError, 'Test error')
+      end
+    end
   end
 end


### PR DESCRIPTION
Possible solution to #238 

I think it is a Bad Idea to suppress all exceptions encountered while in the block passed to Profile#profile, but I can see the logic behind suppressing these exceptions.

I've added a new option: `allow_exceptions` which behaves in the following way:

allow_exceptions defaults to false and RubyProf will continue to
suppress all exceptions in this mode and always return a Profile object

If allow_exceptions is set true, RubyProf will raise any exceptions
encountered during profiling and will not return a Profile object