### PR TITLE
Fix -X/--exclude-file option not working.

### DIFF
--- a/lib/ruby-prof/profile/legacy_method_elimination.rb
+++ b/lib/ruby-prof/profile/legacy_method_elimination.rb
@@ -25,6 +25,7 @@ module RubyProf
           next if (l =~ /^(#.*|\s*)$/) # emtpy lines and lines starting with #
           matchers << Regexp.new(l.strip)
         end
+        matchers
       end
 
       # eliminate methods matching matcher


### PR DESCRIPTION
read_regexps_from_file() read the file but never returned the regular
expressions that it read.