### PR TITLE
Adjust AbstractPrinter#editor_uri so it's possible to disable uri

### DIFF
--- a/lib/ruby-prof/printers/abstract_printer.rb
+++ b/lib/ruby-prof/printers/abstract_printer.rb
@@ -28,7 +28,8 @@ module RubyProf
     #                  Default value is :total_time
     #    :editor_uri - Specifies editor uri scheme used for opening files
     #                  e.g. :atm or :mvim. For OS X default is :txmt.
-    #                  Use RUBY_PROF_EDITOR_URI environment variable to overide.
+    #                  Pass false to print bare filenames.
+    #                  Use RUBY_PROF_EDITOR_URI environment variable to override.
     def setup_options(options = {})
       @options = options
     end
@@ -46,13 +47,13 @@ module RubyProf
     end
 
     def editor_uri
-      default_uri = if RUBY_PLATFORM =~ /darwin/ \
-                    && !ENV['RUBY_PROF_EDITOR_URI']
-                      'txmt'
-                    else
-                      false
-                    end
-      ENV['RUBY_PROF_EDITOR_URI'] || @options[:editor_uri] || default_uri
+      if ENV.key?('RUBY_PROF_EDITOR_URI')
+        ENV['RUBY_PROF_EDITOR_URI'] || false
+      elsif @options.key?(:editor_uri)
+        @options[:editor_uri]
+      else
+        RUBY_PLATFORM =~ /darwin/ ? 'txmt' : false
+      end
     end
 
     def method_name(method)

--- a/test/abstract_printer_test.rb
+++ b/test/abstract_printer_test.rb
@@ -1,0 +1,53 @@
+#!/usr/bin/env ruby
+# encoding: UTF-8
+
+require File.expand_path('../test_helper', __FILE__)
+
+class AbstractPrinterTest < TestCase
+  def setup
+    @result = {}
+    @printer = RubyProf::AbstractPrinter.new(@result)
+    @options = {}
+    @printer.setup_options(@options)
+  end
+
+  def test_editor_uri
+    env = {}
+
+    with_const_stubbed('ENV', env) do
+      @options[:editor_uri] = 'nvim'
+
+      env['RUBY_PROF_EDITOR_URI'] = 'atm'
+      assert_equal('atm', @printer.editor_uri)
+
+      env['RUBY_PROF_EDITOR_URI'] = nil
+      assert_equal(false, @printer.editor_uri)
+
+      env.delete('RUBY_PROF_EDITOR_URI')
+      assert_equal('nvim', @printer.editor_uri)
+
+      with_const_stubbed('RUBY_PLATFORM', 'x86_64-darwin18') do
+        assert_equal('nvim', @printer.editor_uri)
+
+        @options.delete(:editor_uri)
+        assert_equal('txmt', @printer.editor_uri)
+      end
+      with_const_stubbed('RUBY_PLATFORM', 'windows') do
+        assert_equal(false, @printer.editor_uri)
+      end
+    end
+  end
+
+  private
+
+  def with_const_stubbed(name, value)
+    old_verbose, $VERBOSE = $VERBOSE, nil
+    old_value = Object.const_get(name)
+
+    Object.const_set(name, value)
+    yield
+    Object.const_set(name, old_value)
+
+    $VERBOSE = old_verbose
+  end
+end


### PR DESCRIPTION
It's currently impossible to have the printer print bare file paths under macOS. 

Due to a bug, both configuration methods (env and passing options) only make a change when they are not `false` / `nil`.

This change makes it possible to have bare file paths printed either when `:editor_uri` key is set to false or when `RUBY_PROF_EDITOR_URI` env is set and empty.

Additionally, a exhaustive test case is added for this method of `AbstractPrinter`.