### PR TITLE
measure_process_time: fallback to getrusage

### DIFF
--- a/ext/ruby_prof/rp_measure_process_time.c
+++ b/ext/ruby_prof/rp_measure_process_time.c
@@ -15,17 +15,21 @@ measure_process_time(rb_trace_arg_t* trace_arg)
     FILETIME  sysTime;
     FILETIME  userTime;
 
-	ULARGE_INTEGER sysTimeInt;
-	ULARGE_INTEGER userTimeInt;
+    ULARGE_INTEGER sysTimeInt;
+    ULARGE_INTEGER userTimeInt;
 
-	GetProcessTimes(GetCurrentProcess(), &createTime, &exitTime, &sysTime, &userTime); 
+    GetProcessTimes(GetCurrentProcess(), &createTime, &exitTime, &sysTime, &userTime);
 
-	sysTimeInt.LowPart = sysTime.dwLowDateTime;
-	sysTimeInt.HighPart = sysTime.dwHighDateTime;
+    sysTimeInt.LowPart = sysTime.dwLowDateTime;
+    sysTimeInt.HighPart = sysTime.dwHighDateTime;
     userTimeInt.LowPart = userTime.dwLowDateTime;
     userTimeInt.HighPart = userTime.dwHighDateTime;
 
-	return sysTimeInt.QuadPart + userTimeInt.QuadPart;
+    return sysTimeInt.QuadPart + userTimeInt.QuadPart;
+#elif !defined(CLOCK_PROCESS_CPUTIME_ID)
+    struct rusage usage;
+    getrusage(RUSAGE_SELF, &usage);
+    return usage.ru_stime.tv_sec + usage.ru_utime.tv_sec + ((usage.ru_stime.tv_usec + usage.ru_utime.tv_usec)/1000000.0);
 #else
     struct timespec clock;
     clock_gettime(CLOCK_PROCESS_CPUTIME_ID , &clock);


### PR DESCRIPTION
This PR fixes compilation on older OSX. `clock_gettime` was introduced since [OSX Sierra 10.12](http://www.manpagez.com/man/3/clock_gettime/).

Test on newer macs with both getrusage and clock_gettime gave me quite similar results and tests passed.

El Captain is almost 4 years old now, but some models stuck with El Captain and upgrading dev environment is always a PITA.