### PR TITLE
Remove obsolete autoload for `AggregateCallInfo`

### DIFF
--- a/lib/ruby-prof.rb
+++ b/lib/ruby-prof.rb
@@ -18,7 +18,6 @@ require 'ruby-prof/rack'
 require 'ruby-prof/thread'
 
 module RubyProf
-  autoload :AggregateCallInfo, 'ruby-prof/aggregate_call_info'
   autoload :CallInfoVisitor, 'ruby-prof/call_info_visitor'
 
   autoload :AbstractPrinter, 'ruby-prof/printers/abstract_printer'


### PR DESCRIPTION
This class appears to have been removed in b9e83413237beacfc8466bc8319bb9935ca6fc6b.

Thanks