### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/ruby-prof.gemspec
+++ b/ruby-prof.gemspec
@@ -19,6 +19,13 @@ EOF
   spec.license = 'BSD-2-Clause'
   spec.version = RubyProf::VERSION
 
+  spec.metadata = {
+    "bug_tracker_uri"   => "https://github.com/ruby-prof/ruby-prof/issues",
+    "changelog_uri"     => "https://github.com/ruby-prof/ruby-prof/blob/master/CHANGES",
+    "documentation_uri" => "https://ruby-prof.github.io/",
+    "source_code_uri"   => "https://github.com/ruby-prof/ruby-prof/tree/v#{spec.version}",
+  }
+
   spec.author = "Shugo Maeda, Charlie Savage, Roger Pack, Stefan Kaes"
   spec.email = "shugo@ruby-lang.org, cfis@savagexi.com, rogerdpack@gmail.com, skaes@railsexpress.de"
   spec.platform = Gem::Platform::RUBY


### PR DESCRIPTION
Add `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, and `source_code_uri` to the gemspec metadata.

These [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. The URI will be available on the [Rubygems project page](https://rubygems.org/gems/ruby-prof), via the rubygems API, and the `gem` and `bundle` command-line tools with the next release.