### PR TITLE
Add max_percent and filter_by options

### DIFF
--- a/lib/ruby-prof/printers/abstract_printer.rb
+++ b/lib/ruby-prof/printers/abstract_printer.rb
@@ -17,9 +17,19 @@ module RubyProf
       @output = nil
     end
 
-    # Returns the min_percent of total time a method must take to be included in a profiling report
+    # Returns the min_percent of time a method must take to be included in a profiling report
     def min_percent
       @options[:min_percent] || 0
+    end
+
+    # Returns the max_percent of time a method can take to be included in a profiling report
+    def max_percent
+      @options[:max_percent] || 100
+    end
+
+    # Returns the method to filter methods by (when using min_percent and max_percent)
+    def filter_by
+      @options[:filter_by] || :self_time
     end
 
     # Returns the time format used to show when a profile was run

--- a/lib/ruby-prof/printers/flat_printer.rb
+++ b/lib/ruby-prof/printers/flat_printer.rb
@@ -29,8 +29,9 @@ module RubyProf
 
       sum = 0
       methods.each do |method|
-        self_percent = (method.self_time / total_time) * 100
-        next if self_percent < min_percent
+        percent = (method.send(filter_by) / total_time) * 100
+        next if percent < min_percent
+        next if percent > max_percent
 
         sum += method.self_time
         #self_time_called = method.called > 0 ? method.self_time/method.called : 0

--- a/test/printer_flat_test.rb
+++ b/test/printer_flat_test.rb
@@ -65,4 +65,31 @@ class PrinterFlatTest < TestCase
       assert_sorted times
     end
   end
+
+  def test_flat_result_max_percent
+    printer = RubyProf::FlatPrinter.new(@result)
+
+    printer.print(output = '', max_percent: 1)
+    self_percents = flat_output_nth_column_values(output, 1).map(&:to_f)
+
+    assert self_percents.max < 1
+  end
+
+  def test_flat_result_filter_by_total_time
+    printer = RubyProf::FlatPrinter.new(@result)
+
+    printer.print(output = '', filter_by: :total_time, min_percent: 50)
+    total_times = flat_output_nth_column_values(output, 2).map(&:to_f)
+
+    assert (total_times.min / total_times.max) >= 0.5
+  end
+
+  def test_flat_result_filter_by_self_time
+    printer = RubyProf::FlatPrinter.new(@result)
+
+    printer.print(output = '', filter_by: :self_time, min_percent: 0.1)
+    self_percents = flat_output_nth_column_values(output, 1).map(&:to_f)
+
+    assert self_percents.min >= 0.1
+  end
 end


### PR DESCRIPTION
These options are complementary: max_percent adds the ability to exclude results over a particular threshold. filter_by allows the results to be filtered (using min_percent and max_percent) by a different metric than self_time.

Using `filter_by: :total_time, max_percent: 90` (for example) is a convenient way to exclude items from the top of the call stack that might not be very interesting, and simply wrap expensive calls further down.

Addresses https://github.com/ruby-prof/ruby-prof/issues/267.