### PR TITLE
Better require_relative loading

### DIFF
--- a/lib/ruby-prof.rb
+++ b/lib/ruby-prof.rb
@@ -4,9 +4,13 @@ require 'rubygems/version'
 # Load the C-based binding.
 begin
   version = Gem::Version.new(RUBY_VERSION)
-  require "#{version.segments[0..1].join('.')}/ruby_prof.so"
+  require "#{version.segments[0..1].join('.')}/ruby_prof.#{RbConfig::CONFIG["DLEXT"]}"
 rescue LoadError
-  require_relative "../ext/ruby_prof/ruby_prof.so"
+  begin
+    require_relative "ruby_prof.#{RbConfig::CONFIG["DLEXT"]}"
+  rescue LoadError
+    require_relative "../ext/ruby_prof/ruby_prof.#{RbConfig::CONFIG["DLEXT"]}"
+  end
 end
 
 require 'ruby-prof/version'

--- a/lib/ruby-prof.rb
+++ b/lib/ruby-prof.rb
@@ -4,12 +4,12 @@ require 'rubygems/version'
 # Load the C-based binding.
 begin
   version = Gem::Version.new(RUBY_VERSION)
-  require "#{version.segments[0..1].join('.')}/ruby_prof.#{RbConfig::CONFIG["DLEXT"]}"
+  require "#{version.segments[0..1].join('.')}/ruby_prof.so"
 rescue LoadError
   begin
-    require_relative "ruby_prof.#{RbConfig::CONFIG["DLEXT"]}"
+    require_relative "ruby_prof.so"
   rescue LoadError
-    require_relative "../ext/ruby_prof/ruby_prof.#{RbConfig::CONFIG["DLEXT"]}"
+    require_relative "../ext/ruby_prof/ruby_prof.so"
   end
 end
 


### PR DESCRIPTION
~~Fixes to use DLEXT because e.g. Macs ".bundle" files and not ".so"~~

Also we wipe the ext dir in our installs since those files are normally
not used in the runtime at all.  The library is copied into the lib
dir though.

In case the ext dir was deliberate for development process that I'm
not aware of, I retained that as a final fallback.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>