### PR TITLE
CI: Omit duplicate 'bundle install'

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,8 +21,6 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-    - name: Configure
-      run: bundle install
     - name: Build
       run: bundle exec rake compile
     - name: Test


### PR DESCRIPTION
The comment in the `setup-ruby` action step before mentions 'bundle install' having happened already.