### PR TITLE
Actions - change 3.0 to '3.0', add Windows mswin

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,7 +12,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        ruby: [2.5, 2.6, 2.7, 3.0, 3.1]
+        ruby: [2.5, 2.6, 2.7, '3.0', 3.1]
+        include:
+          - { os: windows-latest , ruby: mswin }
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Due to an issue with the yaml parser used by Actions, elements like `3.0` and `3.10` are treated as numbers, and the trailing zero is truncated.  Hence, `3.0` becomes `3`.  So, the Ruby version selected is probably not intended.

See https://github.com/ruby-prof/ruby-prof/actions/runs/3403477040/jobs/5660027501#step:3:15 which incorrectly selects Ruby 3.1.2.

1. Fix above by quoting `3.0`.

2. Add Ruby mswin to matrix.  I noticed some commits referencing msvc, the mswin build is a msvc build of Ruby head.  At present, no release versions are available with GitHub Actions.

When running Actions CI in my fork, results were intermittent.