### PR TITLE
Custom printer support

### DIFF
--- a/bin/ruby-prof
+++ b/bin/ruby-prof
@@ -129,7 +129,8 @@ module RubyProf
                 '  call_tree - format for KCacheGrind',
                 '  call_stack - prints a HTML visualization of the call tree',
                 '  dot - Prints a graph profile as a dot file',
-                '  multi - Creates several reports in output directory'
+                '  multi - Creates several reports in output directory',
+                '  <class name> - Use a custom class'
         ) do |printer|
 
 
@@ -138,11 +139,13 @@ module RubyProf
           elsif printer.modulize == printer # if this is already in a modularized, it's a class
             options.printer_class_name = printer
           else
-            raise "FIXME"
+            puts "Invalid printer: #{printer}"
+            puts opts
+            exit(-1)
           end
         end
 
-        opts.on('--printer-require=require') do |require|
+        opts.on('--printer-require=require', 'A ruby class to load for loading the printer') do |require|
           options.printer_require = require
         end
 
@@ -243,12 +246,26 @@ module RubyProf
 
     def load_printer
       if options.printer_require
-        require options.printer_require
+        begin
+          require options.printer_require
+        rescue LoadError
+          puts "Couldn't require #{options.printer_require} Double check that it is correct, and any gems needed are installed"
+          puts
+          puts option_parser
+          exit(-1)
+        end
       end
 
       # class name given? constantize it now
       if options.printer_class_name
-        options.printer = constantize(options.printer_class_name)
+        begin
+          options.printer = constantize(options.printer_class_name)
+        rescue NameError
+          puts "Couldn't find #{options.printer_class_name} to use as a printer. Double check that it is correct, and that you have given a --printer-require if necessary."
+          puts
+          puts option_parser
+          exit(-1)
+        end
       end
     end
 

--- a/bin/ruby-prof
+++ b/bin/ruby-prof
@@ -6,6 +6,7 @@ require 'ruby-prof'
 # Now setup option parser
 require 'ostruct'
 require 'optparse'
+require 'facets/string/modulize'
 
 module RubyProf
   # == Synopsis
@@ -52,6 +53,8 @@ module RubyProf
     # :enddoc:
     attr_accessor :options
     attr_reader :profile
+
+    BUILTIN_PRINTERS = [:flat, :flat_with_line_numbers, :graph, :graph_html, :call_tree, :call_stack, :dot, :multi].freeze
 
     def initialize
       setup_options
@@ -118,7 +121,7 @@ module RubyProf
         opts.separator ""
         opts.separator "Options:"
 
-        opts.on('-p printer', '--printer=printer', [:flat, :flat_with_line_numbers, :graph, :graph_html, :call_tree, :call_stack, :dot, :multi],
+        opts.on('-p printer', '--printer=printer',
                 'Select a printer:',
                 '  flat - Prints a flat profile as text (default).',
                 '  graph - Prints a graph profile as text.',
@@ -129,22 +132,18 @@ module RubyProf
                 '  multi - Creates several reports in output directory'
         ) do |printer|
 
-          case printer
-          when :flat
-            options.printer = RubyProf::FlatPrinter
-          when :graph
-            options.printer = RubyProf::GraphPrinter
-          when :graph_html
-            options.printer = RubyProf::GraphHtmlPrinter
-          when :call_tree
-            options.printer = RubyProf::CallTreePrinter
-          when :call_stack
-            options.printer = RubyProf::CallStackPrinter
-          when :dot
-            options.printer = RubyProf::DotPrinter
-          when :multi
-            options.printer = RubyProf::MultiPrinter
+
+          if BUILTIN_PRINTERS.include?(printer.to_sym)
+            options.printer_class_name = "RubyProf::#{printer}Printer".modulize
+          elsif printer.modulize == printer # if this is already in a modularized, it's a class
+            options.printer_class_name = printer
+          else
+            raise "FIXME"
           end
+        end
+
+        opts.on('--printer-require=require') do |require|
+          options.printer_require = require
         end
 
         opts.on('-m min_percent', '--min_percent=min_percent', Float,
@@ -242,6 +241,17 @@ module RubyProf
       end
     end
 
+    def load_printer
+      if options.printer_require
+        require options.printer_require
+      end
+
+      # class name given? constantize it now
+      if options.printer_class_name
+        options.printer = constantize(options.printer_class_name)
+      end
+    end
+
     def parse_args
       # Make sure the user specified at least one file
       if ARGV.length < 1 and not options.exec
@@ -252,6 +262,9 @@ module RubyProf
       end
 
       self.option_parser.parse! ARGV
+
+      # make sure it's loaded from options in time to check for directory
+      load_printer
 
       if options.printer.needs_dir?
         options.file ||= "."

--- a/ruby-prof.gemspec
+++ b/ruby-prof.gemspec
@@ -59,6 +59,7 @@ EOF
   spec.required_ruby_version = '>= 2.7.0'
   spec.date = Time.now.strftime('%Y-%m-%d')
   spec.homepage = 'https://github.com/ruby-prof/ruby-prof'
+  spec.add_dependency("facets")
   spec.add_development_dependency('minitest')
   spec.add_development_dependency('rake-compiler')
 end


### PR DESCRIPTION
I'd like to be able to use a custom printer from the command-line. Specifically, [ruby-prof-speedscope](https://github.com/chanzuckerberg/ruby-prof-speedscope).

I've extended the CLI to:

- update --printer to allow a class name
- add --printer-require for the file to require to use a printer

I ended up adding `facets` to get the `String#modularize` method. If this approach is generally acceptable, but an extra dependency isn't, I'm happy to extract copy it or ActiveSupport's implementation, similar to what is done for `constantize`