### PR TITLE
Add option --dont-start and make current profile available as RubyProf::Profile.current

### DIFF
--- a/bin/ruby-prof
+++ b/bin/ruby-prof
@@ -45,6 +45,7 @@ module RubyProf
   #                                       self - Self time
   #                                       wait - Wait time
   #                                       child - Child time
+  #        --start-paused               Pause the profile immediately (resume manually with RubyProf::Profile.current.resume)
   #        --track_allocations          Track allocations while profiling
   #    -v, --version version            Show version (1.1.0)
   #    -h, --help                       Show help message
@@ -73,6 +74,7 @@ module RubyProf
       options.pre_libs = Array.new
       options.pre_execs = Array.new
       options.printer = RubyProf::FlatPrinter
+      options.start_paused = false
       options.track_allocations = false
     end
 
@@ -232,6 +234,10 @@ module RubyProf
                                 end
         end
 
+        opts.on('--start-paused', "Pause the profile immediately (resume manually with RubyProf::Profile.current.resume)") do
+          options.start_paused = true
+        end
+
         opts.on('--track_allocations', 'Track allocations while profiling') do
           options.track_allocations = true
         end
@@ -299,8 +305,9 @@ module RubyProf
       end
 
       script = ARGV.shift
-      profile.profile do
-       load script
+
+      profile.profile paused: options.start_paused do
+        load script
       end
     end
   end

--- a/ext/ruby_prof/rp_profile.c
+++ b/ext/ruby_prof/rp_profile.c
@@ -668,6 +668,8 @@ static VALUE prof_start(VALUE self)
         }
     }
 
+    rb_iv_set(cProfile, "@current", self);
+
     prof_install_hook(self);
     return self;
 }
@@ -748,6 +750,8 @@ static VALUE prof_stop(VALUE self)
        and the threads table */
     profile->running = profile->paused = Qfalse;
     profile->last_thread_data = NULL;
+
+    rb_iv_set(cProfile, "@current", Qnil);
 
     return self;
 }

--- a/lib/ruby-prof/profile.rb
+++ b/lib/ruby-prof/profile.rb
@@ -4,6 +4,10 @@ require 'ruby-prof/exclude_common_methods'
 
 module RubyProf
   class Profile
+    class << self
+      attr_accessor :current
+    end
+
     def measure_mode_string
       case self.measure_mode
         when WALL_TIME

--- a/test/profile_test.rb
+++ b/test/profile_test.rb
@@ -5,6 +5,24 @@ require File.expand_path('../test_helper', __FILE__)
 require_relative './call_tree_builder'
 
 class ProfileTest < TestCase
+  def test_current
+    profile = RubyProf::Profile.new
+    refute_same(profile, RubyProf::Profile.current)
+
+    yielded = false
+    profile.profile do
+      yielded = true
+      assert_same(profile, RubyProf::Profile.current)
+    end
+    assert(yielded)
+    assert_nil(RubyProf::Profile.current)
+
+    profile.start
+    assert_same(profile, RubyProf::Profile.current)
+    profile.stop
+    assert_nil(RubyProf::Profile.current)
+  end
+
   def test_measure_mode
     profile = RubyProf::Profile.new(:measure_mode => RubyProf::PROCESS_TIME)
     assert_equal(RubyProf::PROCESS_TIME, profile.measure_mode)


### PR DESCRIPTION
This relates to #329.

Since "paused" means running+paused, I didn't name the new option `--start-paused`, but `--dont-start`.

`RubyProf::Profile#initialize` now sets `RubyProf::Profile.current`.

Tested successfully with this script:
```ruby
1000.times { puts "." }
RubyProf::Profile.current.start unless RubyProf::Profile.current.running?
1000.times { print "." }
```

For some reason the `ruby-prof` executable had CRLF line endings, which refused to run in my Linux VM. I changed it to LF (Unix). Or did I miss something?