### PR TITLE
Compute prof_method_create->key with the fully-resolved klass

### DIFF
--- a/ext/ruby_prof/rp_method.c
+++ b/ext/ruby_prof/rp_method.c
@@ -141,12 +141,12 @@ prof_method_t* prof_method_create(struct prof_profile_t* profile, VALUE klass, V
     prof_method_t* result = ALLOC(prof_method_t);
     result->profile = profile;
 
-    result->key = method_key(klass, msym);
     result->klass_flags = 0;
 
     /* Note we do not call resolve_klass_name now because that causes an object allocation that shows up
        in the allocation results so we want to avoid it until after the profile run is complete. */
     result->klass = resolve_klass(klass, &result->klass_flags);
+    result->key = method_key(result->klass, msym);
     result->klass_name = Qnil;
     result->method_name = msym;
     result->measurement = prof_measurement_create();


### PR DESCRIPTION
prof_method_create may be called using the `klass` and `method` values from a previous prof_method_create call. However, this may produce a different key from the original prof_method_create call, since key is computed on the raw passed-in klass value the first time, and then on the resolved key the second time. By consistently computing `key` from the resolved klass, copies of a method have a consistent key. This fixes problems with hash table lookup misses resulting in a segfault when merging thread profiles.

See #325 for details.