### PR TITLE
Fix deprecation warning for RubyProf.measure_mode

### DIFF
--- a/lib/ruby-prof/compatibility.rb
+++ b/lib/ruby-prof/compatibility.rb
@@ -100,7 +100,7 @@ module RubyProf
   class << self
     extend Gem::Deprecate
     deprecate :measure_mode, "RubyProf::Profile#measure_mode", 2023, 6
-    deprecate :measure_mode=, "RubyProf::Profile#measure_mode=", 2023, 6
+    deprecate :measure_mode=, "RubyProf::Profile.new(measure_mode: ...)", 2023, 6
     deprecate :exclude_threads, "RubyProf::Profile#exclude_threads", 2023, 6
     deprecate :exclude_threads=, "RubyProf::Profile#initialize", 2023, 6
     deprecate :start, "RubyProf::Profile#start", 2023, 6


### PR DESCRIPTION
Fixes #332.

This PR updates the deprecation warning for `RubyProf.measure_mode=`, which currently suggests using `RubyProf::Profile#measure_mode=`, but causes a `NoMethodError`. The warning now correctly recommends using `RubyProf::Profile.new(measure_mode: ...)` as the proper pattern.
