### PR TITLE
flame_graph_printer.rb: fix false positive recusion detection

### DIFF
--- a/lib/ruby-prof/printers/flame_graph_printer.rb
+++ b/lib/ruby-prof/printers/flame_graph_printer.rb
@@ -49,12 +49,12 @@ module RubyProf
         children: []
       }
 
-      unless visited.include?(call_tree.target)
-        visited.add(call_tree.target)
+      unless visited.include?(call_tree)
+        visited.add(call_tree)
         call_tree.children.sort_by { |c| -c.total_time }.each do |child|
           node[:children] << build_flame_data(child, visited)
         end
-        visited.delete(call_tree.target)
+        visited.delete(call_tree)
       end
 
       node
@@ -69,7 +69,7 @@ module RubyProf
           data: build_flame_data(thread.call_tree)
         }
       end
-      JSON.generate(threads)
+      JSON.generate(threads, max_nesting: 1000)
     end
 
     def template


### PR DESCRIPTION
I believe there is a bug in the flamegraph printer that causes the first time a call site is reached to prevent profiling data from being recorded from further calls into the same location (for example, during iteration over an array).

When profiling Rake tasks, I am seeing this without the patch applied:

<img width="1492" height="558" alt="Screenshot 2026-02-26 at 10 26 02 PM" src="https://github.com/user-attachments/assets/e1a8c129-2f00-4701-bb15-82e1e68a0a2c" />

And this with the patch (snipping the actual task details):

<img width="1477" height="575" alt="Screenshot 2026-02-26 at 10 26 37 PM" src="https://github.com/user-attachments/assets/f0d61db2-06b9-4d13-82aa-17dbddf8512d" />

With this change, we should still be able to detect and avoid loops, if such a thing is possible.

I've additionally increased the `max_nesting` value passed to `JSON.generate` because my application exceeds 100 stack frames.