### PR TITLE
Reduce gem size by excluding test files

### DIFF
--- a/ruby-prof.gemspec
+++ b/ruby-prof.gemspec
@@ -35,12 +35,9 @@ EOF
   spec.extensions = ["ext/ruby_prof/extconf.rb"]
   spec.files = Dir['CHANGELOG.md',
                    'LICENSE',
-                   'Rakefile',
                    'README.md',
-                   'ruby-prof.gemspec',
                    'bin/ruby-prof',
                    'bin/ruby-prof-check-trace',
-                   'docs/**/*',
                    'ext/ruby_prof/extconf.rb',
                    'ext/ruby_prof/*.c',
                    'ext/ruby_prof/*.h',
@@ -51,10 +48,8 @@ EOF
                    'lib/ruby-prof/*.rb',
                    'lib/ruby-prof/assets/*',
                    'lib/ruby-prof/profile/*.rb',
-                   'lib/ruby-prof/printers/*.rb',
-                   'test/*.rb']
+                   'lib/ruby-prof/printers/*.rb']
 
-  spec.test_files = Dir["test/test_*.rb"]
   spec.required_ruby_version = '>= 3.2.0'
   spec.date = Time.now.strftime('%Y-%m-%d')
   spec.homepage = 'https://github.com/ruby-prof/ruby-prof'


### PR DESCRIPTION
This pull request updates the *.gemspec file to optimize the gem package size and structure

```bash
$ gem build -o before.tar

$ git switch reduce-gem-size

$ gem build -o after.tar

$ du -sh before.tar after.tar
 704K	before.tar
 76K	after.tar
 ```
 
| Metric | Before | After | Saved                 |
|--------|--------|-------|-----------------------|
| Size   | 704K   | 76K   | −628K (⏷ −89.2%)        |


###  whitch files was deleted?

```diff
data
 ├── bin
 │   ├── ruby-prof
 │   └── ruby-prof-check-trace
-├── docs
-│   ├── public
-│   │   ├── examples
-│   │   │   ├── reports
-│   │   │   │   ├── call_info.txt
-│   │   │   │   ├── call_stack.html
-│   │   │   │   ├── callgrind.out
-│   │   │   │   ├── flame_graph.html
-│   │   │   │   ├── flat.txt
-│   │   │   │   ├── graph.dot
-│   │   │   │   ├── graph.html
-│   │   │   │   ├── graph.txt
-│   │   │   │   └── graphviz_viewer.html
-│   │   │   ├── example.rb
-│   │   │   └── generate_reports.rb
-│   │   └── images
-│   │       ├── call_stack.png
-│   │       ├── class_diagram.png
-│   │       ├── dot_printer.png
-│   │       ├── flame_graph.png
-│   │       ├── flat.png
-│   │       ├── graph_html.png
-│   │       ├── graph.png
-│   │       └── ruby-prof-logo.svg
-│   ├── stylesheets
-│   │   └── extra.css
-│   ├── advanced-usage.md
-│   ├── alternatives.md
-│   ├── architecture.md
-│   ├── best-practices.md
-│   ├── getting-started.md
-│   ├── history.md
-│   ├── index.md
-│   ├── profiling-rails.md
-│   └── reports.md
 ├── ext
 │   └── ruby_prof
 │       ├── vc
 │       │   ├── ruby_prof.sln
 │       │   └── ruby_prof.vcxproj
 │       ├── extconf.rb
 │       ├── rp_allocation.c
 │       ├── rp_allocation.h
 │       ├── rp_call_tree.c
 │       ├── rp_call_tree.h
 │       ├── rp_call_trees.c
 │       ├── rp_call_trees.h
 │       ├── rp_measure_allocations.c
 │       ├── rp_measure_process_time.c
 │       ├── rp_measure_wall_time.c
 │       ├── rp_measurement.c
 │       ├── rp_measurement.h
 │       ├── rp_method.c
 │       ├── rp_method.h
 │       ├── rp_profile.c
 │       ├── rp_profile.h
 │       ├── rp_stack.c
 │       ├── rp_stack.h
 │       ├── rp_thread.c
 │       ├── rp_thread.h
 │       ├── ruby_prof.c
 │       └── ruby_prof.h
 ├── lib
 │   ├── ruby-prof
 │   │   ├── assets
 │   │   │   ├── call_stack_printer.html.erb
 │   │   │   ├── call_stack_printer.png
 │   │   │   ├── flame_graph_printer.html.erb
 │   │   │   └── graph_printer.html.erb
 │   │   ├── printers
 │   │   │   ├── abstract_printer.rb
 │   │   │   ├── call_info_printer.rb
 │   │   │   ├── call_stack_printer.rb
 │   │   │   ├── call_tree_printer.rb
 │   │   │   ├── dot_printer.rb
 │   │   │   ├── flame_graph_printer.rb
 │   │   │   ├── flat_printer.rb
 │   │   │   ├── graph_html_printer.rb
 │   │   │   ├── graph_printer.rb
 │   │   │   └── multi_printer.rb
 │   │   ├── call_tree_visitor.rb
 │   │   ├── call_tree.rb
 │   │   ├── exclude_common_methods.rb
 │   │   ├── measurement.rb
 │   │   ├── method_info.rb
 │   │   ├── profile.rb
 │   │   ├── rack.rb
 │   │   ├── task.rb
 │   │   ├── thread.rb
 │   │   └── version.rb
 │   ├── ruby-prof.rb
 │   └── unprof.rb
-├── test
-│   ├── abstract_printer_test.rb
-│   ├── alias_test.rb
-│   ├── call_tree_builder.rb
-│   ├── call_tree_test.rb
-│   ├── call_tree_visitor_test.rb
-│   ├── call_trees_test.rb
-│   ├── duplicate_names_test.rb
-│   ├── dynamic_method_test.rb
-│   ├── enumerable_test.rb
-│   ├── exceptions_test.rb
-│   ├── exclude_methods_test.rb
-│   ├── exclude_threads_test.rb
-│   ├── fiber_test.rb
-│   ├── gc_test.rb
-│   ├── inverse_call_tree_test.rb
-│   ├── line_number_test.rb
-│   ├── marshal_test.rb
-│   ├── measure_allocations_test.rb
-│   ├── measure_allocations.rb
-│   ├── measure_process_time_test.rb
-│   ├── measure_times.rb
-│   ├── measure_wall_time_test.rb
-│   ├── measurement_test.rb
-│   ├── merge_test.rb
-│   ├── method_info_test.rb
-│   ├── multi_printer_test.rb
-│   ├── no_method_class_test.rb
-│   ├── pause_resume_test.rb
-│   ├── prime_script.rb
-│   ├── prime.rb
-│   ├── printer_call_stack_test.rb
-│   ├── printer_call_tree_test.rb
-│   ├── printer_flame_graph_test.rb
-│   ├── printer_flat_test.rb
-│   ├── printer_graph_html_test.rb
-│   ├── printer_graph_test.rb
-│   ├── printers_test.rb
-│   ├── printing_recursive_graph_test.rb
-│   ├── profile_test.rb
-│   ├── rack_test.rb
-│   ├── recursive_test.rb
-│   ├── scheduler.rb
-│   ├── singleton_test.rb
-│   ├── stack_printer_test.rb
-│   ├── start_stop_test.rb
-│   ├── test_helper.rb
-│   ├── thread_test.rb
-│   ├── unique_call_path_test.rb
-│   └── yarv_test.rb
 ├── CHANGELOG.md
 ├── LICENSE
-├── Rakefile
 ├── README.md
-└── ruby-prof.gemspec
```

ps: you can see on [rails repo](https://github.com/rails/rails/blob/main/actioncable/actioncable.gemspec#L20)